### PR TITLE
Add support for glibc 2.27

### DIFF
--- a/osdep/machines/glibc/common/include/features.h
+++ b/osdep/machines/glibc/common/include/features.h
@@ -3,7 +3,7 @@
 
 #if defined(_GLIBC2_12) || defined(_GLIBC2_14) || defined(_GLIBC2_15) \
 	|| defined(_GLIBC2_17) || defined(_GLIBC2_18) || defined(_GLIBC2_19) \
-	|| defined(_GLIBC2_31)
+	|| defined(_GLIBC2_27) || defined(_GLIBC2_31)
 #pragma TenDRA begin
 #pragma TenDRA directive warning allow
 #endif

--- a/osdep/machines/glibc/common/include/float.h
+++ b/osdep/machines/glibc/common/include/float.h
@@ -9,7 +9,7 @@
 #if defined(_GLIBC2_5) || defined(_GLIBC2_7) || defined(_GLIBC2_11) \
 	|| defined(_GLIBC2_12) || defined(_GLIBC2_14) || defined(_GLIBC2_15) \
 	|| defined(_GLIBC2_17) || defined(_GLIBC2_18) || defined(_GLIBC2_19) \
-	|| defined(_GLIBC2_31)
+	|| defined(_GLIBC2_27) || defined(_GLIBC2_31)
 
 #include <proxy/include/float.h>
 

--- a/osdep/machines/glibc/common/include/stdarg.h
+++ b/osdep/machines/glibc/common/include/stdarg.h
@@ -4,7 +4,7 @@
 #if defined(_GLIBC2_5) || defined(_GLIBC2_7) || defined(_GLIBC2_11) \
 	|| defined(_GLIBC2_12) || defined(_GLIBC2_14) || defined(_GLIBC2_15) \
 	|| defined(_GLIBC2_17) || defined(_GLIBC2_18) || defined(_GLIBC2_19) \
-	|| defined(_GLIBC2_31)
+	|| defined(_GLIBC2_27) || defined(_GLIBC2_31)
 
 /*
  * The definition of va_list is compatible with the system header.

--- a/osdep/machines/glibc/common/include/stddef.h
+++ b/osdep/machines/glibc/common/include/stddef.h
@@ -9,7 +9,7 @@
 #if defined(_GLIBC2_5) || defined(_GLIBC2_7) || defined(_GLIBC2_11) \
 	|| defined(_GLIBC2_12) || defined(_GLIBC2_14) || defined(_GLIBC2_15) \
 	|| defined(_GLIBC2_17) || defined(_GLIBC2_18) || defined(_GLIBC2_19) \
-	|| defined(_GLIBC2_31)
+	|| defined(_GLIBC2_27) || defined(_GLIBC2_31)
 
 #if defined(_ARCH_x86_32) || defined(_ARCH_x32_64)
 typedef unsigned int size_t;

--- a/osdep/machines/glibc/common/startup/c89.h
+++ b/osdep/machines/glibc/common/startup/c89.h
@@ -6,6 +6,7 @@
 
 #if defined(_GLIBC2_12) || defined(_GLIBC2_15) || defined(_GLIBC2_17) \
 	|| defined(_GLIBC2_19) \
+	|| defined(_GLIBC2_27) \
 	|| defined(_GLIBC2_31)
 #define __STRICT_ANSI__
 #endif

--- a/shared/mk/tendra.makedefs.mk
+++ b/shared/mk/tendra.makedefs.mk
@@ -192,6 +192,7 @@ MD_LIBCVER!=                              \
         GLIBC_2_17*)   echo GLIBC2_17;;   \
         GLIBC_2_18*)   echo GLIBC2_18;;   \
         GLIBC_2_19*)   echo GLIBC2_19;;   \
+        GLIBC_2_27*)   echo GLIBC2_27;;   \
         GLIBC_2_31*)   echo GLIBC2_31;;   \
         MUSL_1_1_5)    echo MUSL1_1_5;;   \
         *)             echo ${MD_OSVER};; \


### PR DESCRIPTION
This patch adds support for glibc version 2.27. The compiler still can't be bootstrapped though owing to the TLS issues, but this gets the GCC built version working at least.