### PR TITLE
Fix some variables being defined multiple times

### DIFF
--- a/libexds/include/exds/istream.h
+++ b/libexds/include/exds/istream.h
@@ -62,7 +62,7 @@ extern ExceptionT *XX_istream_read_error;
  * standard input.  The istream_setup function must be called before this
  * constant is used.
  */
-IStreamT *const istream_input;
+extern IStreamT *const istream_input;
 
 /*
  * This function initialises the input stream facility.  It should be called

--- a/trans/src/common/dwarf1/dw1_info.c
+++ b/trans/src/common/dwarf1/dw1_info.c
@@ -60,8 +60,6 @@ static dwarf_label lex_blk_stk[100];
 				error(ERR_INTERNAL, "lex stk underflow");	\
 			}
 
-FILE *as_file;
-
 static void
 out_dwarf_start_scope(dwarf_label *l)
 {

--- a/trans/src/common/dwarf1/dw1_out.c
+++ b/trans/src/common/dwarf1/dw1_out.c
@@ -54,7 +54,6 @@
 #endif
 
 #if TRANS_X86
-FILE *as_file;
 #define outnl()	fprintf(as_file, "\n")	/* avoid side effects of x86 outnl */
 #else
 #define outnl() asm_printf("\n");

--- a/tspec/src/hash.h
+++ b/tspec/src/hash.h
@@ -64,15 +64,15 @@ void init_hash(void);
  *
  * These hash tables represent the basic namespaces.
  */
-hash_table *exps;
-hash_table *files;
-hash_table *keywords;
-hash_table *subsets;
-hash_table *tags;
-hash_table *tag_fields;
-hash_table *tokens;
-hash_table *types;
-hash_table *type_fields;
+extern hash_table *exps;
+extern hash_table *files;
+extern hash_table *keywords;
+extern hash_table *subsets;
+extern hash_table *tags;
+extern hash_table *tag_fields;
+extern hash_table *tokens;
+extern hash_table *types;
+extern hash_table *type_fields;
 
 #endif
 


### PR DESCRIPTION
GCC 10 will throw an error in this cases.

```
ld: /build/tendra-git/src/tendra/obj.anubis-bootstrap/obj/trans/src/x86/_partial/src/common/dwarf1/dw1_out.o:(.bss+0x0): multiple definition of `as_file'; /build/tendra-git/src/tendra/obj.anubis-bootstrap/obj/trans/src/x86/_partial/src/common/dwarf1/dw1_info.o:(.bss+0x0): first defined here
```