### PR TITLE
Bugfix flags for tendra.prog

### DIFF
--- a/shared/mk/tendra.prog.mk
+++ b/shared/mk/tendra.prog.mk
@@ -33,7 +33,7 @@ EXEC_BIN?=	${PREFIX}/bin
 ${OBJ_SDIR}/${PROG}: ${OBJS}
 	@${CONDCREATE} "${OBJ_SDIR}"
 	@${ECHO} "==> Linking ${WRKDIR}/${PROG}"
-	${CC} ${LDOPTS} -o ${.TARGET} ${OBJS} ${LIBS}
+	${CC} ${CFLAGS} ${LDOPTS} -o ${.TARGET} ${OBJS} ${LIBS}
 
 
 


### PR DESCRIPTION
Noticed while trying to build tendra with gcc -m32 that this bit wasn't using those flags