### PR TITLE
[WIP] Attempt at fixing bootstrap-rebuild

### DIFF
--- a/tspec/base/c/c89/errno.h.ts
+++ b/tspec/base/c/c89/errno.h.ts
@@ -4,7 +4,10 @@
 # See doc/copyright/ for the full copyright terms.
 
 # 4.1.3 Errors <errno.h>
-+EXP lvalue int errno;
+
++FUNC (extern) int *__errno_location(void);
++DEFINE errno %% (*__errno_location ()) %%;
+
 +SUBSET "enums" := {
 	+CONST int EDOM, ERANGE;
 };

--- a/tspec/base/posix/posix/errno.h.ts
+++ b/tspec/base/posix/posix/errno.h.ts
@@ -3,8 +3,8 @@
 #
 # See doc/copyright/ for the full copyright terms.
 
-
-+EXP (extern) int errno ;
++FUNC (extern) int *__errno_location(void);
++DEFINE errno %% (*__errno_location ()) %%;
 
 +SUBSET "enums" := {
     +IMPLEMENT "c/c89", "errno.h.ts", "enums" ;


### PR DESCRIPTION
At least fixes https://github.com/tendra/tendra/issues/7

Although no idea if this is the correct way of course - With these changes there is no reference to `errno` anymore in the symbol table of the object files (well, the 1 I tested with readelf) and now contains a reference to `__errno_location` instead.

Either way, the original error doesn't occur anymore, but here's the next one:
```
==> Linking src/tcc
/opt/compiler-explorer/tendra-source/tendra/obj.ubi2-bootstrap/bin/tcc -Yposix -Xp  -o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/tcc /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/_partial/src/shared/_partial.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/archive.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/compile.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/environ.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/execute.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/filename.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/flags.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/lexer.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/list.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/main.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/options.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/stages.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/startup.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/utility.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/table.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/hash.o /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/temp.o 
/usr/lib/i386-linux-gnu/libc_nonshared.a(atexit.oS): In function `atexit':
(.text+0x11): undefined reference to `__dso_handle'
/usr/bin/ld: /opt/compiler-explorer/tendra-source/tendra/obj.ubi2-rebuild/obj/tcc/src/tcc: hidden symbol `__dso_handle' isn't defined
/usr/bin/ld: final link failed: Bad value
*** Error code 1
```

