### PR TITLE
Allow //-comments in C99 mode

### DIFF
--- a/tcc/startup/lang/c99.h
+++ b/tcc/startup/lang/c99.h
@@ -18,6 +18,9 @@
 
 #pragma TenDRA declaration block end
 
+/* 6.4.9#2 */
+#pragma TenDRA option "cpplus_comment" allow
+
 /* 6.10.3 */
 #pragma TenDRA option "va_macro" allow
 


### PR DESCRIPTION
This sets `cpplus_comment` for C99 per #33. The option itself should probably be renamed (C99 refers to them as "// comments").

We don't actually have a way to have tcc bring in each `startup/lang/$lang.h` mode yet. That needs a bit more thinking about. I'm not sure if the idea of a language standard belongs in tcc's C code, or in its environment files, or in tspec's environment files — and for any of those, how it relates to C++.
https://github.com/tendra/tendra/issues/18 would address this.

I would like to combine STARTUP and STARTUP_CPP if possible. And perhaps not set that in quite so many environments.

When cherry-picking Stefan's commit here, I elided this from the Xc mode because these belong to the language standard, and Xc is supposed to conform exactly to each standard.