### PR TITLE
Fix #39 - rebuild files compiled as partial objects if required

### DIFF
--- a/shared/mk/tendra.partial.mk
+++ b/shared/mk/tendra.partial.mk
@@ -37,7 +37,7 @@ OBJS+=	${PARTS:C/^/${OBJ_SDIR}\/_partial\//:C/$/\/_partial.o/}
 # TODO: override OBJ_* etc when calling ${MAKE}
 # TODO: pass through CFLAGS etc (call these PART_CFLAGS, PART_CCOPTS etc)
 # TODO: directory here is ${OBJ_SDIR}/_partial/installers/80x86/common
-${OBJ_SDIR}/_partial/${part}/_partial.o:
+${OBJ_SDIR}/_partial/${part}/_partial.o::
 	@cd ${BASE_DIR}/${part} && ${MAKE}        \
 	    BASE_DIR=${BASE_DIR}                  \
 	    OBJ_DIR=${OBJ_SDIR}/_partial          \


### PR DESCRIPTION
Replaces the `:` operator with the `::` operator in `_partial.o` targets. Since no sources are specified to the `partial.o` target it will always be recreated and so will always recursively call `${MAKE} ... _partial` which actually knows about the partial target files and can then rebuild the object file if any of it's constituent files have changed. If that makes any sense... yay for Makefiles 😄

Reference from the `bmake` man page

>     ::    If no sources are specified, the target is always re-created.  Otherwise, a target is considered out-of-date
>           if any of its sources has been modified more recently than the target.  Sources for a target do not accumu‐
>           late over dependency lines when this operator is used.  The target will not be removed if bmake is inter‐
>           rupted.



