### PR TITLE
Still generate code for X86 dwarf2/diag4 if 'diag' not set

### DIFF
--- a/trans/src/x86/make_code.c
+++ b/trans/src/x86/make_code.c
@@ -2725,6 +2725,8 @@ make_code(where dest, ash stack, exp e)
 #ifdef DWARF2
 			dw2_code_info(dgf(e), make_code2, (void*) &args);
 #endif
+		} else {
+			make_code1(dest, stack, e);
 		}
 
 		if (dpos) {


### PR DESCRIPTION
Previously if the x86 backend was configured to use diag4/dwarf2 and an expression had diagnostic information but the `diag` enum is unset (as it appears to be in for diag4 currently, along with a bunch of other things such as `diag4_driver`) then no code would be generated. This patch resolves that issue by still generating code with `make_code1` if `diag == DIAG_NONE`.

This patch appears to fix #13.

For example for the following simple program
```c
#include <stdio.h>
int main(int argc, char** argv) {
	int a;
	int c;

	if (argc != 2)
		return 1;

	a = atoi(argv[1]);
	c = a * 2;

	printf("%i\n", c);
	return 0;
}
```

X86 built with diag3 would generate the following (correct) code
```asm
080483a0 <main>:
 80483a0:	56                   	push   %esi
 80483a1:	55                   	push   %ebp
 80483a2:	83 7c 24 0c 02       	cmpl   $0x2,0xc(%esp)
 80483a7:	74 08                	je     80483b1 <main+0x11>
 80483a9:	b8 01 00 00 00       	mov    $0x1,%eax
 80483ae:	5d                   	pop    %ebp
 80483af:	5e                   	pop    %esi
 80483b0:	c3                   	ret    
 80483b1:	8b 54 24 10          	mov    0x10(%esp),%edx
 80483b5:	8b 42 04             	mov    0x4(%edx),%eax
 80483b8:	50                   	push   %eax
 80483b9:	e8 62 ff ff ff       	call   8048320 <atoi@plt>
 80483be:	5a                   	pop    %edx
 80483bf:	89 c5                	mov    %eax,%ebp
 80483c1:	8d 74 2d 00          	lea    0x0(%ebp,%ebp,1),%esi
 80483c5:	56                   	push   %esi
 80483c6:	68 1c a0 04 08       	push   $0x804a01c
 80483cb:	e8 30 ff ff ff       	call   8048300 <printf@plt>
 80483d0:	5a                   	pop    %edx
 80483d1:	5a                   	pop    %edx
 80483d2:	31 c0                	xor    %eax,%eax
 80483d4:	5d                   	pop    %ebp
 80483d5:	5e                   	pop    %esi
 80483d6:	c3                   	ret    
 80483d7:	90                   	nop
 80483d8:	90                   	nop
 80483d9:	8d b4 26 00 00 00 00 	lea    0x0(%esi,%eiz,1),%esi
```
but if built with the diag4/dwarf2 backend the following (incorrect) code would be generated.
```asm
08048320 <main>:
 8048320:       56                      push   %esi
 8048321:       55                      push   %ebp
 8048322:       b8 01 00 00 00          mov    $0x1,%eax
 8048327:       5d                      pop    %ebp
 8048328:       5e                      pop    %esi
 8048329:       c3                      ret    
 804832a:       8d 74 2d 00             lea    0x0(%ebp,%ebp,1),%esi
 804832e:       31 c0                   xor    %eax,%eax
 8048330:       5d                      pop    %ebp
 8048331:       5e                      pop    %esi
 8048332:       c3                      ret    
 8048333:       90                      nop
 8048334:       8d b6 00 00 00 00       lea    0x0(%esi),%esi
 804833a:       8d bf 00 00 00 00       lea    0x0(%edi),%edi
```
which just appears to skip random instructions.

This patch fixes X86 with `diag4`/`dwarf2` so that it generates the same code as the `diag3` implementation.

I'm not sure what the automated testing situation is at the moment, but I don't know if "function generates code" would go well into a contained test case anyway. Regardless from my testing it appears to work - I can't test if the correct debug information is generated however as trying to pass `-g` to tcc crashes the compiler, for both diag3 and diag4 without this patch, but that appears to be a separate issue.

This patch also doesn't switch the back to using `diag4` as there still appears to be work required on it (like does the `diag4_driver` structure need to be set, or the `diag` enum that causes this problem? and other things probably). So to see the effects of this patch  `TRANS_DEBUG` will need to be set to `dwarf2` in `trans/src/x86/Makefile`.