### PR TITLE
The return of do_prom

### DIFF
--- a/trans/man/trans.1/trans.1.xml
+++ b/trans/man/trans.1/trans.1.xml
@@ -813,7 +813,8 @@
 				<term>&N.opt;</term>
 
 				<listitem>
-					<para>Produce PROM code (avoiding <code>.data</code>).</para>
+					<para>Produce PROM code (avoiding <code>.data</code>).
+						This implies &Y.opt;.</para>
 				</listitem>
 			</varlistentry>
 
@@ -1109,7 +1110,8 @@
 				<term>&Y.opt;</term>
 
 				<listitem>
-					<para>Produce calls for dynamic initialisation.</para>
+					<para>Produce calls for dynamic initialisation.
+						&Y.opt; is set automatically when &N.opt; is used.</para>
 				</listitem>
 			</varlistentry>
 

--- a/trans/src/common/construct/install_fns.c
+++ b/trans/src/common/construct/install_fns.c
@@ -55,6 +55,7 @@
 #include <special/special_fn.h>
 
 #include <utility/max.h>
+#include <utility/prefix.h>
 
 #include <main/flags.h>
 
@@ -6247,11 +6248,17 @@ tidy_initial_values(void)
 			prom_as = add_exp_list(prom_as, hold_refactor(f_assign(
 					       me_obtain(list_exp),
 					       me_obtain(str_exp))), 0);
+		} else {
+			dec *extra_dec;	
+			extra_dec = make_extra_dec(add_prefix(name_prefix, init_NAME(good_name)),	
+				0, 1, prc, f_proc);	
+			(void) extra_dec; /* XXX: suspicious; should this value be used? */
 		}
 	}
 	if (do_prom && prom_as.number != 0) {
 		/* ie there are some prom initialisations */
 		exp prc;
+		dec *extra_dec;
 		tagshacc_list tsl;
 
 		exp ret = f_return(f_make_top());
@@ -6261,5 +6268,8 @@ tidy_initial_values(void)
 		rep_make_proc = false;
 		start_make_proc(f_top, tsl, no_tagacc_option);
 		prc = f_make_proc(f_top, tsl, no_tagacc_option, seq);
+		extra_dec = make_extra_dec(add_prefix(name_prefix, init_NAME(good_name)),	
+			0, 1, prc, f_proc);	
+		(void) extra_dec; /* XXX: suspicious; should this value be used? */
 	}
 }

--- a/trans/src/common/main/main.c
+++ b/trans/src/common/main/main.c
@@ -244,6 +244,11 @@ main(int argc, char *argv[])
 		return 0;
 	}
 
+	/* PROM code depends on emitting dynamic initialisers */
+	if (do_prom) {
+		dyn_init = 1;
+	}
+
 	{
 		size_t i;
 

--- a/trans/src/common/main/main.c
+++ b/trans/src/common/main/main.c
@@ -158,7 +158,7 @@ main(int argc, char *argv[])
 		char opts[256];
 		int c;
 
-		sprintf(opts, "%s%s", "A:B:C:DE:F:G:H:IK:MO:PQRS:VWX:YZ" "TJ" "hv", driver.opts);
+		sprintf(opts, "%s%s", "A:B:C:DE:F:G:H:IK:MNO:PQRS:VWX:YZ" "TJ" "hv", driver.opts);
 
 		while (c = getopt(argc, argv, opts), c != -1) {
 			switch (c) {

--- a/trans/src/x86/assembler.h
+++ b/trans/src/x86/assembler.h
@@ -23,7 +23,6 @@ void eval_postlude(char *s, exp c);
 void out_readonly_section(void);
 void out_dot_comm(char *name, shape sha);
 void out_dot_lcomm(char *name, shape sha);
-void out_bss(char *name, shape sha);
 
 void pic_prelude(void);
 

--- a/trans/src/x86/translate.c
+++ b/trans/src/x86/translate.c
@@ -264,7 +264,8 @@ code_def(dec *d)
 							asm_printf(".globl %s\n", name);
 						}
 
-						out_bss(name, sh(child(tag)));
+						out_dot_lcomm(name, sh(child(tag)));
+
 #ifdef DWARF2
 						if (diag == DIAG_DWARF2) {
 							note_data(name);


### PR DESCRIPTION
I'd accidentally disabled the `-Wt,-N` flag for trans at some point. This PR returns it. It was already present in the manpage.

While I was here I saw that I'd removed a call to `make_extra_dec()` when `do_prom` (set by -N) is true. That was removed in b06dca2, where I evidently considered it unused code. Here I'm effectively reverting that removal.

From my commit:
> As far as I can tell, these calls just construct a dec struct, but don't actually use it. However this also invokes `add_prefix()` and `init_NAME()`, and essentially I just don't believe
so much code can be unused.

Now compiling a simple hello world with `-Wt,-N` gives:
```
/tmp/tcc-MX19JN1NJ6/_tcc.s: Assembler messages:
/tmp/tcc-MX19JN1NJ6/_tcc.s:28: Error: bad or irreducible absolute expression
/tmp/tcc-MX19JN1NJ6/_tcc.s:28: Error: junk at end of line, first unrecognized character is `,'
/tmp/tcc-MX19JN1NJ6/_tcc.s:29: Error: bad or irreducible absolute expression
/tmp/tcc-MX19JN1NJ6/_tcc.s:29: Error: junk at end of line, first unrecognized character is `,'
```
which seems to be caused by the `.bss` directives here:
```
.align 4
.size main, .-main
.bss .L0, 12
.bss .L1, 8
.section .rodata
.align 4
.L2:
.byte 104, 101, 108, 108, 111, 32, 37, 115, 10, 0
```
Perhaps these are unrelated, and need porting to GAS's dialect? I'm not sure. The syntax looks correct per the documentation for Sun's as(1) at least.