### PR TITLE
Avoid calling exit from an atexit callback

### DIFF
--- a/shared/include/error.h
+++ b/shared/include/error.h
@@ -26,6 +26,9 @@ void fmt_register(char c, void (*f)(FILE *fp, void *));
 
 extern const char *progname;
 extern const char *progvers;
+/* Set the variable "exiting" to nonzero prior to
+   calling error() from an atexit() callback: */
+extern int exiting;
 extern int exit_status;
 extern unsigned long maximum_errors;
 extern unsigned long number_errors;

--- a/shared/src/error.c
+++ b/shared/src/error.c
@@ -17,6 +17,7 @@
 const char *progname = NULL;
 const char *progvers = NULL;
 
+int exiting = 0;
 int exit_status = EXIT_SUCCESS;
 unsigned long maximum_errors = 20;
 unsigned long number_errors = 0;
@@ -124,7 +125,10 @@ error_msg(enum error_severity e, const char *fn, int ln, const char *s, va_list 
 	IGNORE fprintf(stderr, "\n");
 
 	if (e == ERR_FATAL || e == ERR_USAGE) {
-		exit(exit_status);
+		if (exiting)
+			_Exit(exit_status);
+		else
+			exit(exit_status);
 	}
 
 	if (number_errors >= maximum_errors && maximum_errors) {

--- a/shared/src/error.c
+++ b/shared/src/error.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <shared/check.h>
 #include <shared/error.h>
@@ -126,7 +127,7 @@ error_msg(enum error_severity e, const char *fn, int ln, const char *s, va_list 
 
 	if (e == ERR_FATAL || e == ERR_USAGE) {
 		if (exiting)
-			_Exit(exit_status);
+			_exit(exit_status);
 		else
 			exit(exit_status);
 	}

--- a/tcc/src/main.c
+++ b/tcc/src/main.c
@@ -55,6 +55,7 @@ print_version(void)
 static void
 main_end(void)
 {
+	exiting = 1;
 	remove_junk();
 	remove_startup();
 	if (tempdir != NULL &&


### PR DESCRIPTION
Fixes https://github.com/tendra/tendra/issues/40

I chose to call `_Exit` because it is part of C99. It is also possible to call `_exit` (the POSIX name for the same function); in fact `tcc/src/main.c` already does `#include <unistd.h>` (the POSIX header that provides `_exit` and that would have to be included in `error.c` in order to call `_exit` in that file). But in 2020, depending on a C99 function seems the least constraining requirement.

I made the variable `exiting` an `int` in case using `_Bool` would complicate TenDRA's bootstrap. It should be a `_Bool`.