### PR TITLE
Set -Yposix per file during rebuild

### DIFF
--- a/shared/mk/tendra.obj.mk
+++ b/shared/mk/tendra.obj.mk
@@ -25,18 +25,30 @@ OBJS+=  ${SRCS:S/.cc/.o/:S/.c/.o/:C/^/${OBJ_SDIR}\//}
 CCOPTS+=	-I ${BASE_DIR}/include
 .endif
 
+# XXX: I don't like this being here much; in particular to have a special case
+# for ${TCC} outside of tendra.compiler.mk. But this depends on ${SRC}, which
+# likewise doesn't belong in that .mk file.
+# Meanwhile I hope we can eventually be rid of any special case flags here.
+.if defined(TCC)
+. for src in ${SRCS:M*.c}
+.  if defined(TCCOPTS.${src})
+CCOPTS.${src}+=	${TCCOPTS.${src}}
+.  endif
+. endfor
+.endif
+
 .for src in ${SRCS:M*.c}
 ${OBJ_SDIR}/${src:S/.c/.o/}: ${src}
 	@${CONDCREATE} "${OBJ_SDIR}"
 	@${ECHO} "==> Compiling ${WRKDIR}/${src}"
-	${CC} ${CFLAGS} ${CCOPTS} -c ${.ALLSRC} -o ${.TARGET}
+	${CC} ${CFLAGS} ${CCOPTS} ${CCOPTS.${src}} -c ${.ALLSRC} -o ${.TARGET}
 .endfor
 
 .for src in ${SRCS:M*.cc}
 ${OBJ_SDIR}/${src:S/.cc/.o/}: ${src}
 	@${CONDCREATE} "${OBJ_SDIR}"
 	@${ECHO} "==> Compiling ${WRKDIR}/${src}"
-	${CXX} ${CXXFLAGS} ${CCOPTS} -c ${.ALLSRC} -o ${.TARGET}
+	${CXX} ${CXXFLAGS} ${CCOPTS} ${CCOPTS.${src}} -c ${.ALLSRC} -o ${.TARGET}
 .endfor
 
 

--- a/tcc/src/Makefile
+++ b/tcc/src/Makefile
@@ -11,7 +11,14 @@ PARTS+=	src/shared
 .include <tendra.partial.mk>
 
 
-TCCOPTS=	-Yposix -Xp
+TCCOPTS=	-Xp
+
+TCCOPTS.archive.c	+= -Yposix
+TCCOPTS.environ.c	+= -Yposix
+TCCOPTS.execute.c	+= -Yposix
+TCCOPTS.filename.c	+= -Yposix
+TCCOPTS.main.c	+= -Yposix
+TCCOPTS.hash.c	+= -Yposix
 
 CCOPTS+=                                   \
 	-DEXECFORMAT='"${EXECFORMAT}"'         \

--- a/tdfc2/src/c/Makefile
+++ b/tdfc2/src/c/Makefile
@@ -1,7 +1,5 @@
 # $Id$
 
-TCCOPTS=	-Yposix
-
 .include "Makefile.inc"
 
 

--- a/tdfc2/src/common/Makefile
+++ b/tdfc2/src/common/Makefile
@@ -10,8 +10,6 @@ CCOPTS+=	-I output
 CCOPTS+=	-I spec
 CCOPTS+=	-I .
 
-TCCOPTS+= -Yposix
-
 SRCS+=	main.c
 
 .include <tendra.obj.mk>

--- a/tdfc2/src/common/parse/Makefile
+++ b/tdfc2/src/common/parse/Makefile
@@ -15,6 +15,8 @@ CCOPTS+=	-I ../../common/obj_c
 CCOPTS+=	-I ../../common/output
 CCOPTS+=	-I ../../common
 
+TCCOPTS.file.c	+= -Yposix
+
 SRCS!=	ls -1 psyntax*.c
 
 SRCS+=	char.c

--- a/tdfc2/src/common/spec/Makefile
+++ b/tdfc2/src/common/spec/Makefile
@@ -12,6 +12,8 @@ CCOPTS+=	-I ../../common/obj_c
 CCOPTS+=	-I ../../common/parse
 CCOPTS+=	-I ../../common
 
+TCCOPTS.load.c+=	-Yposix
+
 SRCS+=	load.c
 SRCS+=	save.c
 

--- a/tdfc2/src/common/utility/Makefile
+++ b/tdfc2/src/common/utility/Makefile
@@ -9,7 +9,7 @@ CCOPTS+=	-I ../../common/output
 CCOPTS+=	-I ../../common/parse
 CCOPTS+=	-I ../../common
 
-TCCOPTS+= -Yposix
+TCCOPTS.system.c+=	-Yposix
 
 SRCS+=	buffer.c
 SRCS+=	catalog.c

--- a/tdfc2/src/cpp/Makefile
+++ b/tdfc2/src/cpp/Makefile
@@ -1,7 +1,5 @@
 # $Id$
 
-TCCOPTS=      -Yposix
-
 .include "Makefile.inc"
 
 

--- a/tld/src/Makefile
+++ b/tld/src/Makefile
@@ -11,7 +11,9 @@ PARTS+=	src/frontend
 .include <tendra.partial.mk>
 
 
-TCCOPTS=	-Yposix -Xs
+TCCOPTS=	-Xs
+
+TCCOPTS.file-name.c+=	-Yposix
 
 CCOPTS+=	-I .
 

--- a/trans/src/m68k/Makefile
+++ b/trans/src/m68k/Makefile
@@ -54,7 +54,7 @@ PARTS+= src/common/main
 .include <tendra.partial.mk>
 
 
-#TCCOPTS=	-Xc -Y32bit -Yposix
+#TCCOPTS=	-Xc -Y32bit
 
 CCOPTS+=	${TRANS_CFLAGS}
 

--- a/tspec/src/Makefile
+++ b/tspec/src/Makefile
@@ -11,7 +11,7 @@ PARTS+=	src/out
 
 CCOPTS+= -I .
 
-TCCOPTS+= -Yposix
+TCCOPTS.utility.c+=	-Yposix
 
 SRCS+=	hash.c
 SRCS+=	lex.c


### PR DESCRIPTION
This helps see exactly where -Yposix is needed. Which is in more places than I'd hoped.

I think the big take-away here is that it's (of course) used all over tcc.

In practice unless we can find a PL_TDF arrangement for errno or similar (proposed in #37 and #57), I think most of these -Yposix flags will eventually have to be moved to a more recent standard instead. Which is fine, it just places more of a porting burden for a larger API.