### PR TITLE
Fix out-of-bounds access in nstring_ci_equal.

### DIFF
--- a/libexds/src/dstring.c
+++ b/libexds/src/dstring.c
@@ -177,11 +177,11 @@ nstring_ci_equal(NStringT *nstring1, NStringT *nstring2)
 		char c2;
 
 		do {
-			c1 = toupper((unsigned char) *tmp1++);
-			c2 = toupper((unsigned char) *tmp2++);
 			if (length-- == 0) {
 				return true;
 			}
+			c1 = toupper((unsigned char) *tmp1++);
+			c2 = toupper((unsigned char) *tmp2++);
 		} while (c1 == c2);
 	}
 


### PR DESCRIPTION
The loop body would fetch the next characters of the passed-in strings and convert them to uppercase, then check whether the strings have more characters, and finally compare the uppercased characters. When the string has no more characters, no characters should be fetched, so this reorders the checks to handle that.

(This is the out-of-bounds read I saw reported by valgrind on sid.)