### PR TITLE
Fix sid build with GCC 10 / -fno-common

### DIFF
--- a/sid/src/lang-c/c-lexer.h
+++ b/sid/src/lang-c/c-lexer.h
@@ -23,7 +23,7 @@
 #include "c-lexi_lexer.h"
 
 
-struct c_lexi_state c_lexer_current_state ;
+extern struct c_lexi_state c_lexer_current_state ;
 
 /*
  * Note:
@@ -111,6 +111,6 @@ void		c_lexer_save_terminal(CLexerStreamT *, CTokenT);
 void		c_lexer_restore_terminal(CLexerStreamT *);
 
 /* XXX remove once lexi provides opaque pointers */
-CLexerStreamT *c_lexer_stream;
+extern CLexerStreamT *c_lexer_stream;
 
 #endif /* !defined (H_C_LEXER) */

--- a/sid/src/lang-c/c-parser.act
+++ b/sid/src/lang-c/c-parser.act
@@ -137,9 +137,9 @@
 	#include "c-lexer.h"
 	#include "c-out-info.h"
 
-	CLexerStreamT *c_current_stream;
-	COutputInfoT  *c_current_out_info;
-	TableT        *c_current_table;
+	extern CLexerStreamT *c_current_stream;
+	extern COutputInfoT  *c_current_out_info;
+	extern TableT        *c_current_table;
 
 @};
 

--- a/sid/src/lang-c/c-parser.c
+++ b/sid/src/lang-c/c-parser.c
@@ -9,8 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 55 "c-parser.act"
-
+#line 26 "c-parser.act"
 
 
 	/*
@@ -104,7 +103,7 @@
 			field, (void *) key, (void *) a, (void *) b);
 	}
 
-#line 109 "c-parser.c"
+#line 107 "c-parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -192,11 +191,11 @@ ZL2_179:;
 			}
 			/* BEGINNING OF ACTION: skip-recover */
 			{
-#line 1110 "c-parser.act"
+#line 1102 "c-parser.act"
 
 		c_propagating_error = false;
 	
-#line 201 "c-parser.c"
+#line 199 "c-parser.c"
 			}
 			/* END OF ACTION: skip-recover */
 			/* BEGINNING OF INLINE: c-parse-grammar::result-assign-list */
@@ -260,11 +259,11 @@ ZL2_186:;
 			}
 			/* BEGINNING OF ACTION: skip-recover */
 			{
-#line 1110 "c-parser.act"
+#line 1102 "c-parser.act"
 
 		c_propagating_error = false;
 	
-#line 269 "c-parser.c"
+#line 267 "c-parser.c"
 			}
 			/* END OF ACTION: skip-recover */
 			/* BEGINNING OF INLINE: c-parse-grammar::terminal-list */
@@ -298,11 +297,11 @@ ZR113(CCodeP *ZO112)
 		case (C_TOK_ACT_HCODESTART):
 			/* BEGINNING OF EXTRACT: ACT-CODESTART */
 			{
-#line 209 "c-parser.act"
+#line 202 "c-parser.act"
 
 		ZI121 = c_lexer_stream_line(c_current_stream);
 	
-#line 307 "c-parser.c"
+#line 305 "c-parser.c"
 			}
 			/* END OF EXTRACT: ACT-CODESTART */
 			break;
@@ -312,11 +311,11 @@ ZR113(CCodeP *ZO112)
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ccode-init */
 		{
-#line 741 "c-parser.act"
+#line 734 "c-parser.act"
 
 		(ZI112) = c_code_create(istream_name(&c_lexer_stream->istream), (ZI121));
 	
-#line 321 "c-parser.c"
+#line 319 "c-parser.c"
 		}
 		/* END OF ACTION: ccode-init */
 		ZR119 (ZI112);
@@ -355,11 +354,11 @@ ZR132(void)
 				{
 					/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 					{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI134, c_lexer_string_value(c_current_stream));
 	
-#line 364 "c-parser.c"
+#line 362 "c-parser.c"
 					}
 					/* END OF EXTRACT: C-IDENTIFIER */
 					ADVANCE_LEXER;
@@ -369,11 +368,11 @@ ZR132(void)
 				{
 					/* BEGINNING OF EXTRACT: SID-IDENTIFIER */
 					{
-#line 177 "c-parser.act"
+#line 170 "c-parser.act"
 
 		nstring_assign(&ZI134, c_lexer_string_value(c_current_stream));
 	
-#line 378 "c-parser.c"
+#line 376 "c-parser.c"
 					}
 					/* END OF EXTRACT: SID-IDENTIFIER */
 					ADVANCE_LEXER;
@@ -386,7 +385,7 @@ ZR132(void)
 		/* END OF INLINE: c-parse-grammar::identifier */
 		/* BEGINNING OF ACTION: set-map */
 		{
-#line 279 "c-parser.act"
+#line 272 "c-parser.act"
 
 		c_current_entry = table_get_entry(c_current_table, (&ZI134));
 		if (c_current_entry == NULL) {
@@ -416,7 +415,7 @@ ZR132(void)
 		}
 		nstring_destroy(&(ZI134));
 	
-#line 421 "c-parser.c"
+#line 419 "c-parser.c"
 		}
 		/* END OF ACTION: set-map */
 		ZR163 ();
@@ -433,11 +432,11 @@ ZR132(void)
 				case (C_TOK_C_HIDENTIFIER):
 					/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 					{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI137, c_lexer_string_value(c_current_stream));
 	
-#line 442 "c-parser.c"
+#line 440 "c-parser.c"
 					}
 					/* END OF EXTRACT: C-IDENTIFIER */
 					break;
@@ -447,7 +446,7 @@ ZR132(void)
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: x-set-map */
 				{
-#line 310 "c-parser.act"
+#line 302 "c-parser.act"
 
 		if (c_current_entry) {
 			entry_set_mapping(c_current_entry, &(ZI137));
@@ -455,7 +454,7 @@ ZR132(void)
 			nstring_destroy(&(ZI137));
 		}
 	
-#line 460 "c-parser.c"
+#line 458 "c-parser.c"
 				}
 				/* END OF ACTION: x-set-map */
 				ZR223 ();
@@ -469,18 +468,18 @@ ZR132(void)
 			{
 				/* BEGINNING OF ACTION: expected-c-identifier */
 				{
-#line 811 "c-parser.act"
+#line 801 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("C identifier");
 		}
 	
-#line 480 "c-parser.c"
+#line 478 "c-parser.c"
 				}
 				/* END OF ACTION: expected-c-identifier */
 				/* BEGINNING OF ACTION: skip-to-end-of-map */
 				{
-#line 954 "c-parser.act"
+#line 947 "c-parser.act"
 
 		while (CURRENT_TERMINAL != (C_TOK_EOF)
 			&& CURRENT_TERMINAL != (C_TOK_TERMINATOR)
@@ -508,7 +507,7 @@ ZR132(void)
 
 		c_propagating_error = true;
 	
-#line 513 "c-parser.c"
+#line 511 "c-parser.c"
 				}
 				/* END OF ACTION: skip-to-end-of-map */
 			}
@@ -542,13 +541,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-arrow */
 		{
-#line 835 "c-parser.act"
+#line 825 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("'->'");
 		}
 	
-#line 553 "c-parser.c"
+#line 551 "c-parser.c"
 		}
 		/* END OF ACTION: expected-arrow */
 	}
@@ -570,11 +569,11 @@ ZR166(void)
 				{
 					/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 					{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI109, c_lexer_string_value(c_current_stream));
 	
-#line 579 "c-parser.c"
+#line 577 "c-parser.c"
 					}
 					/* END OF EXTRACT: C-IDENTIFIER */
 					ADVANCE_LEXER;
@@ -584,11 +583,11 @@ ZR166(void)
 				{
 					/* BEGINNING OF EXTRACT: SID-IDENTIFIER */
 					{
-#line 177 "c-parser.act"
+#line 170 "c-parser.act"
 
 		nstring_assign(&ZI109, c_lexer_string_value(c_current_stream));
 	
-#line 593 "c-parser.c"
+#line 591 "c-parser.c"
 					}
 					/* END OF EXTRACT: SID-IDENTIFIER */
 					ADVANCE_LEXER;
@@ -601,7 +600,7 @@ ZR166(void)
 		/* END OF INLINE: c-parse-grammar::identifier */
 		/* BEGINNING OF ACTION: assign */
 		{
-#line 377 "c-parser.act"
+#line 370 "c-parser.act"
 
 		c_current_entry = table_get_type(c_current_table, (&ZI109));
 		if (c_current_entry == NULL) {
@@ -613,7 +612,7 @@ ZR166(void)
 		}
 		nstring_destroy(&(ZI109));
 	
-#line 618 "c-parser.c"
+#line 616 "c-parser.c"
 		}
 		/* END OF ACTION: assign */
 		ZR147 ();
@@ -634,7 +633,7 @@ ZR166(void)
 				}
 				/* BEGINNING OF ACTION: x-assign */
 				{
-#line 426 "c-parser.act"
+#line 382 "c-parser.act"
 
 		if (c_current_entry) {
 			bool  errored = false;
@@ -688,7 +687,7 @@ ZR166(void)
 			c_code_deallocate((ZI170));
 		}
 	
-#line 693 "c-parser.c"
+#line 691 "c-parser.c"
 				}
 				/* END OF ACTION: x-assign */
 				ZR223 ();
@@ -702,18 +701,18 @@ ZR166(void)
 			{
 				/* BEGINNING OF ACTION: expected-code */
 				{
-#line 859 "c-parser.act"
+#line 849 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("code block");
 		}
 	
-#line 713 "c-parser.c"
+#line 711 "c-parser.c"
 				}
 				/* END OF ACTION: expected-code */
 				/* BEGINNING OF ACTION: skip-to-end-of-assignment */
 				{
-#line 982 "c-parser.act"
+#line 975 "c-parser.act"
 
 		while (CURRENT_TERMINAL != (C_TOK_EOF)
 			&& CURRENT_TERMINAL != (C_TOK_TERMINATOR)
@@ -740,7 +739,7 @@ ZR166(void)
 
 		c_propagating_error = true;
 	
-#line 745 "c-parser.c"
+#line 743 "c-parser.c"
 				}
 				/* END OF ACTION: skip-to-end-of-assignment */
 			}
@@ -780,11 +779,11 @@ ZR195(void)
 						{
 							/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 							{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI109, c_lexer_string_value(c_current_stream));
 	
-#line 789 "c-parser.c"
+#line 787 "c-parser.c"
 							}
 							/* END OF EXTRACT: C-IDENTIFIER */
 							ADVANCE_LEXER;
@@ -794,11 +793,11 @@ ZR195(void)
 						{
 							/* BEGINNING OF EXTRACT: SID-IDENTIFIER */
 							{
-#line 177 "c-parser.act"
+#line 170 "c-parser.act"
 
 		nstring_assign(&ZI109, c_lexer_string_value(c_current_stream));
 	
-#line 803 "c-parser.c"
+#line 801 "c-parser.c"
 							}
 							/* END OF EXTRACT: SID-IDENTIFIER */
 							ADVANCE_LEXER;
@@ -811,7 +810,7 @@ ZR195(void)
 				/* END OF INLINE: c-parse-grammar::identifier */
 				/* BEGINNING OF ACTION: set-action */
 				{
-#line 656 "c-parser.act"
+#line 649 "c-parser.act"
 
 		c_current_entry = table_get_action(c_current_table, (&ZI109));
 		if (c_current_entry == NULL) {
@@ -829,7 +828,7 @@ ZR195(void)
 		}
 		nstring_destroy(&(ZI109));
 	
-#line 834 "c-parser.c"
+#line 832 "c-parser.c"
 				}
 				/* END OF ACTION: set-action */
 				/* BEGINNING OF INLINE: 198 */
@@ -848,13 +847,13 @@ ZR195(void)
 					{
 						/* BEGINNING OF ACTION: expected-end-action */
 						{
-#line 847 "c-parser.act"
+#line 837 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("'>'");
 		}
 	
-#line 859 "c-parser.c"
+#line 857 "c-parser.c"
 						}
 						/* END OF ACTION: expected-end-action */
 					}
@@ -879,7 +878,7 @@ ZR195(void)
 						}
 						/* BEGINNING OF ACTION: x-set-action */
 						{
-#line 711 "c-parser.act"
+#line 667 "c-parser.act"
 
 		if (c_current_entry) {
 			ActionT    *action  = entry_get_action(c_current_entry);
@@ -931,7 +930,7 @@ ZR195(void)
 			c_code_deallocate((ZI170));
 		}
 	
-#line 936 "c-parser.c"
+#line 934 "c-parser.c"
 						}
 						/* END OF ACTION: x-set-action */
 						ZR223 ();
@@ -945,18 +944,18 @@ ZR195(void)
 					{
 						/* BEGINNING OF ACTION: expected-code */
 						{
-#line 859 "c-parser.act"
+#line 849 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("code block");
 		}
 	
-#line 956 "c-parser.c"
+#line 954 "c-parser.c"
 						}
 						/* END OF ACTION: expected-code */
 						/* BEGINNING OF ACTION: skip-to-end-of-action */
 						{
-#line 1085 "c-parser.act"
+#line 1078 "c-parser.act"
 
 		while (CURRENT_TERMINAL != (C_TOK_EOF)
 			&& CURRENT_TERMINAL != (C_TOK_TERMINATOR)
@@ -980,7 +979,7 @@ ZR195(void)
 
 		c_propagating_error = true;
 	
-#line 985 "c-parser.c"
+#line 983 "c-parser.c"
 						}
 						/* END OF ACTION: skip-to-end-of-action */
 					}
@@ -993,18 +992,18 @@ ZR195(void)
 			{
 				/* BEGINNING OF ACTION: expected-identifier */
 				{
-#line 805 "c-parser.act"
+#line 795 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 1004 "c-parser.c"
+#line 1002 "c-parser.c"
 				}
 				/* END OF ACTION: expected-identifier */
 				/* BEGINNING OF ACTION: skip-to-end-of-action */
 				{
-#line 1085 "c-parser.act"
+#line 1078 "c-parser.act"
 
 		while (CURRENT_TERMINAL != (C_TOK_EOF)
 			&& CURRENT_TERMINAL != (C_TOK_TERMINATOR)
@@ -1028,7 +1027,7 @@ ZR195(void)
 
 		c_propagating_error = true;
 	
-#line 1033 "c-parser.c"
+#line 1031 "c-parser.c"
 				}
 				/* END OF ACTION: skip-to-end-of-action */
 			}
@@ -1060,13 +1059,13 @@ ZL2_154:;
 			{
 				/* BEGINNING OF ACTION: is-close-tuple-or-skipped-or-eof */
 				{
-#line 1113 "c-parser.act"
+#line 1106 "c-parser.act"
 
 		(ZI0) = (CURRENT_TERMINAL == (C_TOK_CLOSE_HTUPLE)
 			|| CURRENT_TERMINAL == (C_TOK_EOF)
 			|| c_propagating_error);
 	
-#line 1071 "c-parser.c"
+#line 1069 "c-parser.c"
 				}
 				/* END OF ACTION: is-close-tuple-or-skipped-or-eof */
 				if (!ZI0)
@@ -1092,13 +1091,13 @@ ZL2_154:;
 			{
 				/* BEGINNING OF ACTION: expected-separator */
 				{
-#line 817 "c-parser.act"
+#line 807 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("','");
 		}
 	
-#line 1103 "c-parser.c"
+#line 1101 "c-parser.c"
 				}
 				/* END OF ACTION: expected-separator */
 				/* BEGINNING OF INLINE: c-parse-grammar::function-type-defn::tuple-defn-list-1 */
@@ -1130,11 +1129,11 @@ ZL2_193:;
 			}
 			/* BEGINNING OF ACTION: skip-recover */
 			{
-#line 1110 "c-parser.act"
+#line 1102 "c-parser.act"
 
 		c_propagating_error = false;
 	
-#line 1139 "c-parser.c"
+#line 1137 "c-parser.c"
 			}
 			/* END OF ACTION: skip-recover */
 			/* BEGINNING OF INLINE: c-parse-grammar::action-list */
@@ -1169,11 +1168,11 @@ ZR174(void)
 				{
 					/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 					{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI109, c_lexer_string_value(c_current_stream));
 	
-#line 1178 "c-parser.c"
+#line 1176 "c-parser.c"
 					}
 					/* END OF EXTRACT: C-IDENTIFIER */
 					ADVANCE_LEXER;
@@ -1183,11 +1182,11 @@ ZR174(void)
 				{
 					/* BEGINNING OF EXTRACT: SID-IDENTIFIER */
 					{
-#line 177 "c-parser.act"
+#line 170 "c-parser.act"
 
 		nstring_assign(&ZI109, c_lexer_string_value(c_current_stream));
 	
-#line 1192 "c-parser.c"
+#line 1190 "c-parser.c"
 					}
 					/* END OF EXTRACT: SID-IDENTIFIER */
 					ADVANCE_LEXER;
@@ -1200,7 +1199,7 @@ ZR174(void)
 		/* END OF INLINE: c-parse-grammar::identifier */
 		/* BEGINNING OF ACTION: passign */
 		{
-#line 443 "c-parser.act"
+#line 436 "c-parser.act"
 
 		c_current_entry = table_get_type(c_current_table, (&ZI109));
 		if (c_current_entry == NULL) {
@@ -1212,7 +1211,7 @@ ZR174(void)
 		}
 		nstring_destroy(&(ZI109));
 	
-#line 1217 "c-parser.c"
+#line 1215 "c-parser.c"
 		}
 		/* END OF ACTION: passign */
 		ZR147 ();
@@ -1233,7 +1232,7 @@ ZR174(void)
 				}
 				/* BEGINNING OF ACTION: x-passign */
 				{
-#line 491 "c-parser.act"
+#line 448 "c-parser.act"
 
 		if (c_current_entry) {
 			bool  errored = false;
@@ -1286,7 +1285,7 @@ ZR174(void)
 			c_code_deallocate((ZI170));
 		}
 	
-#line 1291 "c-parser.c"
+#line 1289 "c-parser.c"
 				}
 				/* END OF ACTION: x-passign */
 				ZR223 ();
@@ -1300,18 +1299,18 @@ ZR174(void)
 			{
 				/* BEGINNING OF ACTION: expected-code */
 				{
-#line 859 "c-parser.act"
+#line 849 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("code block");
 		}
 	
-#line 1311 "c-parser.c"
+#line 1309 "c-parser.c"
 				}
 				/* END OF ACTION: expected-code */
 				/* BEGINNING OF ACTION: skip-to-end-of-param-assign */
 				{
-#line 1009 "c-parser.act"
+#line 1002 "c-parser.act"
 
 		while (CURRENT_TERMINAL != (C_TOK_EOF)
 			&& CURRENT_TERMINAL != (C_TOK_TERMINATOR)
@@ -1338,7 +1337,7 @@ ZR174(void)
 
 		c_propagating_error = true;
 	
-#line 1343 "c-parser.c"
+#line 1341 "c-parser.c"
 				}
 				/* END OF ACTION: skip-to-end-of-param-assign */
 			}
@@ -1366,11 +1365,11 @@ ZL2_122:;
 			}
 			/* BEGINNING OF ACTION: skip-recover */
 			{
-#line 1110 "c-parser.act"
+#line 1102 "c-parser.act"
 
 		c_propagating_error = false;
 	
-#line 1375 "c-parser.c"
+#line 1373 "c-parser.c"
 			}
 			/* END OF ACTION: skip-recover */
 			/* BEGINNING OF INLINE: c-parse-grammar::prefix-list */
@@ -1398,11 +1397,11 @@ ZR115(CCodeP ZI112)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: append-ccode-advance */
 			{
-#line 759 "c-parser.act"
+#line 752 "c-parser.act"
 
 		c_code_append_advance((ZI112));
 	
-#line 1407 "c-parser.c"
+#line 1405 "c-parser.c"
 			}
 			/* END OF ACTION: append-ccode-advance */
 		}
@@ -1412,13 +1411,13 @@ ZR115(CCodeP ZI112)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: append-ccode-at */
 			{
-#line 746 "c-parser.act"
+#line 738 "c-parser.act"
 
 		NStringT ns;
 		nstring_copy_cstring(&ns, "@");	/* TODO append '@' to code buffer? */
 		c_code_append_string((ZI112), &ns);	/* TODO really append_label()? */
 	
-#line 1423 "c-parser.c"
+#line 1421 "c-parser.c"
 			}
 			/* END OF ACTION: append-ccode-at */
 		}
@@ -1429,21 +1428,21 @@ ZR115(CCodeP ZI112)
 
 			/* BEGINNING OF EXTRACT: ACT-BASIC */
 			{
-#line 185 "c-parser.act"
+#line 178 "c-parser.act"
 
 		nstring_assign(&ZI117, c_lexer_string_value(c_current_stream));
 	
-#line 1438 "c-parser.c"
+#line 1436 "c-parser.c"
 			}
 			/* END OF EXTRACT: ACT-BASIC */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: append-ccode-basic */
 			{
-#line 763 "c-parser.act"
+#line 756 "c-parser.act"
 
 		c_code_append_basic((ZI112), &(ZI117));
 	
-#line 1448 "c-parser.c"
+#line 1446 "c-parser.c"
 			}
 			/* END OF ACTION: append-ccode-basic */
 		}
@@ -1454,22 +1453,22 @@ ZR115(CCodeP ZI112)
 
 			/* BEGINNING OF EXTRACT: ACT-CODESTRING */
 			{
-#line 205 "c-parser.act"
+#line 198 "c-parser.act"
 
 		nstring_assign(&ZI118, c_lexer_string_value(c_current_stream));
 	
-#line 1463 "c-parser.c"
+#line 1461 "c-parser.c"
 			}
 			/* END OF EXTRACT: ACT-CODESTRING */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: append-ccode-codestring */
 			{
-#line 783 "c-parser.act"
+#line 776 "c-parser.act"
 
 		assert(!nstring_contains(&(ZI118), '@'));	/* XXX '@'? */
 		c_code_append_string((ZI112), &(ZI118));
 	
-#line 1474 "c-parser.c"
+#line 1472 "c-parser.c"
 			}
 			/* END OF ACTION: append-ccode-codestring */
 		}
@@ -1479,12 +1478,12 @@ ZR115(CCodeP ZI112)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: E-eof-in-code-block */
 			{
-#line 790 "c-parser.act"
+#line 781 "c-parser.act"
 
 		error_posn(ERR_SERIOUS, istream_name(&c_lexer_stream->istream), (int) istream_line(&c_lexer_stream->istream),
 			"end of file in C code block");
 	
-#line 1489 "c-parser.c"
+#line 1487 "c-parser.c"
 			}
 			/* END OF ACTION: E-eof-in-code-block */
 		}
@@ -1494,11 +1493,11 @@ ZR115(CCodeP ZI112)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: append-ccode-exception */
 			{
-#line 751 "c-parser.act"
+#line 744 "c-parser.act"
 
 		c_code_append_exception((ZI112));
 	
-#line 1503 "c-parser.c"
+#line 1501 "c-parser.c"
 			}
 			/* END OF ACTION: append-ccode-exception */
 		}
@@ -1509,21 +1508,21 @@ ZR115(CCodeP ZI112)
 
 			/* BEGINNING OF EXTRACT: ACT-IDENTIFIER */
 			{
-#line 197 "c-parser.act"
+#line 190 "c-parser.act"
 
 		nstring_assign(&ZI117, c_lexer_string_value(c_current_stream));
 	
-#line 1518 "c-parser.c"
+#line 1516 "c-parser.c"
 			}
 			/* END OF EXTRACT: ACT-IDENTIFIER */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: append-ccode-identifier */
 			{
-#line 775 "c-parser.act"
+#line 768 "c-parser.act"
 
 		c_code_append_identifier((ZI112), &(ZI117));
 	
-#line 1528 "c-parser.c"
+#line 1526 "c-parser.c"
 			}
 			/* END OF ACTION: append-ccode-identifier */
 		}
@@ -1534,21 +1533,21 @@ ZR115(CCodeP ZI112)
 
 			/* BEGINNING OF EXTRACT: ACT-LABEL */
 			{
-#line 189 "c-parser.act"
+#line 182 "c-parser.act"
 
 		nstring_assign(&ZI117, c_lexer_string_value(c_current_stream));
 	
-#line 1543 "c-parser.c"
+#line 1541 "c-parser.c"
 			}
 			/* END OF EXTRACT: ACT-LABEL */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: append-ccode-label */
 			{
-#line 767 "c-parser.act"
+#line 760 "c-parser.act"
 
 		c_code_append_label((ZI112), &(ZI117));
 	
-#line 1553 "c-parser.c"
+#line 1551 "c-parser.c"
 			}
 			/* END OF ACTION: append-ccode-label */
 		}
@@ -1559,21 +1558,21 @@ ZR115(CCodeP ZI112)
 
 			/* BEGINNING OF EXTRACT: ACT-MODIFIABLE */
 			{
-#line 201 "c-parser.act"
+#line 194 "c-parser.act"
 
 		nstring_assign(&ZI117, c_lexer_string_value(c_current_stream));
 	
-#line 1568 "c-parser.c"
+#line 1566 "c-parser.c"
 			}
 			/* END OF EXTRACT: ACT-MODIFIABLE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: append-ccode-modifiable */
 			{
-#line 779 "c-parser.act"
+#line 772 "c-parser.act"
 
 		c_code_append_modifiable((ZI112), &(ZI117));
 	
-#line 1578 "c-parser.c"
+#line 1576 "c-parser.c"
 			}
 			/* END OF ACTION: append-ccode-modifiable */
 		}
@@ -1584,21 +1583,21 @@ ZR115(CCodeP ZI112)
 
 			/* BEGINNING OF EXTRACT: ACT-REFERENCE */
 			{
-#line 193 "c-parser.act"
+#line 186 "c-parser.act"
 
 		nstring_assign(&ZI117, c_lexer_string_value(c_current_stream));
 	
-#line 1593 "c-parser.c"
+#line 1591 "c-parser.c"
 			}
 			/* END OF EXTRACT: ACT-REFERENCE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: append-ccode-reference */
 			{
-#line 771 "c-parser.act"
+#line 764 "c-parser.act"
 
 		c_code_append_reference((ZI112), &(ZI117));
 	
-#line 1603 "c-parser.c"
+#line 1601 "c-parser.c"
 			}
 			/* END OF ACTION: append-ccode-reference */
 		}
@@ -1608,11 +1607,11 @@ ZR115(CCodeP ZI112)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: append-ccode-terminal */
 			{
-#line 755 "c-parser.act"
+#line 748 "c-parser.act"
 
 		c_code_append_terminal((ZI112));
 	
-#line 1617 "c-parser.c"
+#line 1615 "c-parser.c"
 			}
 			/* END OF ACTION: append-ccode-terminal */
 		}
@@ -1644,11 +1643,11 @@ ZR124(void)
 				{
 					/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 					{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI125, c_lexer_string_value(c_current_stream));
 	
-#line 1653 "c-parser.c"
+#line 1651 "c-parser.c"
 					}
 					/* END OF EXTRACT: C-IDENTIFIER */
 					ADVANCE_LEXER;
@@ -1658,11 +1657,11 @@ ZR124(void)
 				{
 					/* BEGINNING OF EXTRACT: SID-IDENTIFIER */
 					{
-#line 177 "c-parser.act"
+#line 170 "c-parser.act"
 
 		nstring_assign(&ZI125, c_lexer_string_value(c_current_stream));
 	
-#line 1667 "c-parser.c"
+#line 1665 "c-parser.c"
 					}
 					/* END OF EXTRACT: SID-IDENTIFIER */
 					ADVANCE_LEXER;
@@ -1675,7 +1674,7 @@ ZR124(void)
 		/* END OF INLINE: c-parse-grammar::identifier */
 		/* BEGINNING OF ACTION: set-prefix */
 		{
-#line 233 "c-parser.act"
+#line 212 "c-parser.act"
 
 		int prefix;
 
@@ -1702,7 +1701,7 @@ ZR124(void)
 		}
 		nstring_destroy(&(ZI125));
 	
-#line 1707 "c-parser.c"
+#line 1705 "c-parser.c"
 		}
 		/* END OF ACTION: set-prefix */
 		ZR126 ();
@@ -1719,11 +1718,11 @@ ZR124(void)
 				case (C_TOK_C_HIDENTIFIER):
 					/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 					{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI128, c_lexer_string_value(c_current_stream));
 	
-#line 1728 "c-parser.c"
+#line 1726 "c-parser.c"
 					}
 					/* END OF EXTRACT: C-IDENTIFIER */
 					break;
@@ -1733,7 +1732,7 @@ ZR124(void)
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: x-set-prefix */
 				{
-#line 247 "c-parser.act"
+#line 239 "c-parser.act"
 
 		if (c_current_prefix == CPFX_NUM_PREFIXES) {
 			nstring_destroy(&(ZI128));
@@ -1744,7 +1743,7 @@ ZR124(void)
 			nstring_assign(prefix, &(ZI128));
 		}
 	
-#line 1749 "c-parser.c"
+#line 1747 "c-parser.c"
 				}
 				/* END OF ACTION: x-set-prefix */
 				ZR223 ();
@@ -1758,18 +1757,18 @@ ZR124(void)
 			{
 				/* BEGINNING OF ACTION: expected-c-identifier */
 				{
-#line 811 "c-parser.act"
+#line 801 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("C identifier");
 		}
 	
-#line 1769 "c-parser.c"
+#line 1767 "c-parser.c"
 				}
 				/* END OF ACTION: expected-c-identifier */
 				/* BEGINNING OF ACTION: skip-to-end-of-prefix */
 				{
-#line 925 "c-parser.act"
+#line 918 "c-parser.act"
 
 		while (CURRENT_TERMINAL != (C_TOK_EOF)
 			&& CURRENT_TERMINAL != (C_TOK_TERMINATOR)
@@ -1798,7 +1797,7 @@ ZR124(void)
 
 		c_propagating_error = true;
 	
-#line 1803 "c-parser.c"
+#line 1801 "c-parser.c"
 				}
 				/* END OF ACTION: skip-to-end-of-prefix */
 			}
@@ -1889,13 +1888,13 @@ c_parse_grammar(void)
 			{
 				/* BEGINNING OF ACTION: expected-blt-header */
 				{
-#line 865 "c-parser.act"
+#line 855 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("'%header%'");
 		}
 	
-#line 1900 "c-parser.c"
+#line 1898 "c-parser.c"
 				}
 				/* END OF ACTION: expected-blt-header */
 			}
@@ -1914,12 +1913,12 @@ c_parse_grammar(void)
 				}
 				/* BEGINNING OF ACTION: set-header1 */
 				{
-#line 322 "c-parser.act"
+#line 315 "c-parser.act"
 
 		c_code_check((ZI207), false, false, false, NULL, NULL, c_current_table);
 		c_out_info_set_header1(c_current_out_info, (ZI207));
 	
-#line 1924 "c-parser.c"
+#line 1922 "c-parser.c"
 				}
 				/* END OF ACTION: set-header1 */
 			}
@@ -1928,13 +1927,13 @@ c_parse_grammar(void)
 			{
 				/* BEGINNING OF ACTION: expected-code */
 				{
-#line 859 "c-parser.act"
+#line 849 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("code block");
 		}
 	
-#line 1939 "c-parser.c"
+#line 1937 "c-parser.c"
 				}
 				/* END OF ACTION: expected-code */
 			}
@@ -1958,12 +1957,12 @@ c_parse_grammar(void)
 				}
 				/* BEGINNING OF ACTION: set-header2 */
 				{
-#line 327 "c-parser.act"
+#line 320 "c-parser.act"
 
 		c_code_check((ZI210), false, false, false, NULL, NULL, c_current_table);
 		c_out_info_set_header2(c_current_out_info, (ZI210));
 	
-#line 1968 "c-parser.c"
+#line 1966 "c-parser.c"
 				}
 				/* END OF ACTION: set-header2 */
 			}
@@ -1972,13 +1971,13 @@ c_parse_grammar(void)
 			{
 				/* BEGINNING OF ACTION: expected-code */
 				{
-#line 859 "c-parser.act"
+#line 849 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("code block");
 		}
 	
-#line 1983 "c-parser.c"
+#line 1981 "c-parser.c"
 				}
 				/* END OF ACTION: expected-code */
 			}
@@ -2059,13 +2058,13 @@ c_parse_grammar(void)
 			{
 				/* BEGINNING OF ACTION: expected-blt-terminals */
 				{
-#line 871 "c-parser.act"
+#line 861 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("'%terminals%'");
 		}
 	
-#line 2070 "c-parser.c"
+#line 2068 "c-parser.c"
 				}
 				/* END OF ACTION: expected-blt-terminals */
 			}
@@ -2093,13 +2092,13 @@ c_parse_grammar(void)
 			{
 				/* BEGINNING OF ACTION: expected-blt-actions */
 				{
-#line 877 "c-parser.act"
+#line 867 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("'%actions%'");
 		}
 	
-#line 2104 "c-parser.c"
+#line 2102 "c-parser.c"
 				}
 				/* END OF ACTION: expected-blt-actions */
 			}
@@ -2127,13 +2126,13 @@ c_parse_grammar(void)
 			{
 				/* BEGINNING OF ACTION: expected-blt-trailer */
 				{
-#line 883 "c-parser.act"
+#line 873 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("'%trailer%'");
 		}
 	
-#line 2138 "c-parser.c"
+#line 2136 "c-parser.c"
 				}
 				/* END OF ACTION: expected-blt-trailer */
 			}
@@ -2152,12 +2151,12 @@ c_parse_grammar(void)
 				}
 				/* BEGINNING OF ACTION: set-trailer1 */
 				{
-#line 726 "c-parser.act"
+#line 719 "c-parser.act"
 
 		c_code_check((ZI219), false, false, false, NULL, NULL, c_current_table);
 		c_out_info_set_trailer1 (c_current_out_info, (ZI219));
 	
-#line 2162 "c-parser.c"
+#line 2160 "c-parser.c"
 				}
 				/* END OF ACTION: set-trailer1 */
 			}
@@ -2166,13 +2165,13 @@ c_parse_grammar(void)
 			{
 				/* BEGINNING OF ACTION: expected-code */
 				{
-#line 859 "c-parser.act"
+#line 849 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("code block");
 		}
 	
-#line 2177 "c-parser.c"
+#line 2175 "c-parser.c"
 				}
 				/* END OF ACTION: expected-code */
 			}
@@ -2196,12 +2195,12 @@ c_parse_grammar(void)
 				}
 				/* BEGINNING OF ACTION: set-trailer2 */
 				{
-#line 731 "c-parser.act"
+#line 724 "c-parser.act"
 
 		c_code_check((ZI222), false, false, false, NULL, NULL, c_current_table);
 		c_out_info_set_trailer2(c_current_out_info, (ZI222));
 	
-#line 2206 "c-parser.c"
+#line 2204 "c-parser.c"
 				}
 				/* END OF ACTION: set-trailer2 */
 			}
@@ -2210,13 +2209,13 @@ c_parse_grammar(void)
 			{
 				/* BEGINNING OF ACTION: expected-code */
 				{
-#line 859 "c-parser.act"
+#line 849 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("code block");
 		}
 	
-#line 2221 "c-parser.c"
+#line 2219 "c-parser.c"
 				}
 				/* END OF ACTION: expected-code */
 			}
@@ -2244,13 +2243,13 @@ c_parse_grammar(void)
 			{
 				/* BEGINNING OF ACTION: expected-eof */
 				{
-#line 889 "c-parser.act"
+#line 879 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("end of file");
 		}
 	
-#line 2255 "c-parser.c"
+#line 2253 "c-parser.c"
 				}
 				/* END OF ACTION: expected-eof */
 			}
@@ -2263,11 +2262,11 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: unhandled-syntax-error */
 		{
-#line 799 "c-parser.act"
+#line 791 "c-parser.act"
 
 		UNREACHED;
 	
-#line 2272 "c-parser.c"
+#line 2270 "c-parser.c"
 		}
 		/* END OF ACTION: unhandled-syntax-error */
 	}
@@ -2306,11 +2305,11 @@ ZR159(void)
 	{
 		/* BEGINNING OF ACTION: init-tuple */
 		{
-#line 347 "c-parser.act"
+#line 339 "c-parser.act"
 
 		types_init(&c_current_type);
 	
-#line 2315 "c-parser.c"
+#line 2313 "c-parser.c"
 		}
 		/* END OF ACTION: init-tuple */
 		/* BEGINNING OF INLINE: 161 */
@@ -2329,13 +2328,13 @@ ZR159(void)
 			{
 				/* BEGINNING OF ACTION: expected-open-tuple */
 				{
-#line 823 "c-parser.act"
+#line 813 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("'('");
 		}
 	
-#line 2340 "c-parser.c"
+#line 2338 "c-parser.c"
 				}
 				/* END OF ACTION: expected-open-tuple */
 			}
@@ -2349,11 +2348,11 @@ ZR159(void)
 		}
 		/* BEGINNING OF ACTION: skip-recover */
 		{
-#line 1110 "c-parser.act"
+#line 1102 "c-parser.act"
 
 		c_propagating_error = false;
 	
-#line 2358 "c-parser.c"
+#line 2356 "c-parser.c"
 		}
 		/* END OF ACTION: skip-recover */
 		/* BEGINNING OF INLINE: 162 */
@@ -2372,13 +2371,13 @@ ZR159(void)
 			{
 				/* BEGINNING OF ACTION: expected-close-tuple */
 				{
-#line 829 "c-parser.act"
+#line 819 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("')'");
 		}
 	
-#line 2383 "c-parser.c"
+#line 2381 "c-parser.c"
 				}
 				/* END OF ACTION: expected-close-tuple */
 			}
@@ -2409,11 +2408,11 @@ ZR141(void)
 				case (C_TOK_C_HIDENTIFIER):
 					/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 					{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI128, c_lexer_string_value(c_current_stream));
 	
-#line 2418 "c-parser.c"
+#line 2416 "c-parser.c"
 					}
 					/* END OF EXTRACT: C-IDENTIFIER */
 					break;
@@ -2427,22 +2426,22 @@ ZR141(void)
 			{
 				/* BEGINNING OF ACTION: empty-string */
 				{
-#line 270 "c-parser.act"
+#line 263 "c-parser.act"
 
 		nstring_init(&(ZI128));
 	
-#line 2436 "c-parser.c"
+#line 2434 "c-parser.c"
 				}
 				/* END OF ACTION: empty-string */
 				/* BEGINNING OF ACTION: expected-c-identifier */
 				{
-#line 811 "c-parser.act"
+#line 801 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("C identifier");
 		}
 	
-#line 2447 "c-parser.c"
+#line 2445 "c-parser.c"
 				}
 				/* END OF ACTION: expected-c-identifier */
 			}
@@ -2463,11 +2462,11 @@ ZR141(void)
 				case (C_TOK_C_HIDENTIFIER):
 					/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 					{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI145, c_lexer_string_value(c_current_stream));
 	
-#line 2472 "c-parser.c"
+#line 2470 "c-parser.c"
 					}
 					/* END OF EXTRACT: C-IDENTIFIER */
 					break;
@@ -2481,22 +2480,22 @@ ZR141(void)
 			{
 				/* BEGINNING OF ACTION: empty-string */
 				{
-#line 270 "c-parser.act"
+#line 263 "c-parser.act"
 
 		nstring_init(&(ZI145));
 	
-#line 2490 "c-parser.c"
+#line 2488 "c-parser.c"
 				}
 				/* END OF ACTION: empty-string */
 				/* BEGINNING OF ACTION: expected-identifier */
 				{
-#line 805 "c-parser.act"
+#line 795 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 2501 "c-parser.c"
+#line 2499 "c-parser.c"
 				}
 				/* END OF ACTION: expected-identifier */
 			}
@@ -2505,7 +2504,7 @@ ZR141(void)
 		/* END OF INLINE: 144 */
 		/* BEGINNING OF ACTION: set-persistent */
 		{
-#line 257 "c-parser.act"
+#line 250 "c-parser.act"
 
 		if(persistent_list_find(c_out_info_persistents(c_current_out_info), (&ZI128)) == NULL) {
 			PersistentT *p;
@@ -2518,7 +2517,7 @@ ZR141(void)
 			/* TODO error out E_c_persistent_variable_name_conflict((&ZI128))) ;*/
 		}
 	
-#line 2523 "c-parser.c"
+#line 2521 "c-parser.c"
 		}
 		/* END OF ACTION: set-persistent */
 		ZR223 ();
@@ -2549,11 +2548,11 @@ ZR181(void)
 				{
 					/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 					{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI109, c_lexer_string_value(c_current_stream));
 	
-#line 2558 "c-parser.c"
+#line 2556 "c-parser.c"
 					}
 					/* END OF EXTRACT: C-IDENTIFIER */
 					ADVANCE_LEXER;
@@ -2563,11 +2562,11 @@ ZR181(void)
 				{
 					/* BEGINNING OF EXTRACT: SID-IDENTIFIER */
 					{
-#line 177 "c-parser.act"
+#line 170 "c-parser.act"
 
 		nstring_assign(&ZI109, c_lexer_string_value(c_current_stream));
 	
-#line 2572 "c-parser.c"
+#line 2570 "c-parser.c"
 					}
 					/* END OF EXTRACT: SID-IDENTIFIER */
 					ADVANCE_LEXER;
@@ -2580,7 +2579,7 @@ ZR181(void)
 		/* END OF INLINE: c-parse-grammar::identifier */
 		/* BEGINNING OF ACTION: rassign */
 		{
-#line 508 "c-parser.act"
+#line 501 "c-parser.act"
 
 		c_current_entry = table_get_type(c_current_table, (&ZI109));
 		if (c_current_entry == NULL) {
@@ -2592,7 +2591,7 @@ ZR181(void)
 		}
 		nstring_destroy(&(ZI109));
 	
-#line 2597 "c-parser.c"
+#line 2595 "c-parser.c"
 		}
 		/* END OF ACTION: rassign */
 		ZR147 ();
@@ -2613,7 +2612,7 @@ ZR181(void)
 				}
 				/* BEGINNING OF ACTION: x-rassign */
 				{
-#line 556 "c-parser.act"
+#line 513 "c-parser.act"
 
 		if (c_current_entry) {
 			bool  errored = false;
@@ -2666,7 +2665,7 @@ ZR181(void)
 			c_code_deallocate((ZI170));
 		}
 	
-#line 2671 "c-parser.c"
+#line 2669 "c-parser.c"
 				}
 				/* END OF ACTION: x-rassign */
 				ZR223 ();
@@ -2680,18 +2679,18 @@ ZR181(void)
 			{
 				/* BEGINNING OF ACTION: expected-code */
 				{
-#line 859 "c-parser.act"
+#line 849 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("code block");
 		}
 	
-#line 2691 "c-parser.c"
+#line 2689 "c-parser.c"
 				}
 				/* END OF ACTION: expected-code */
 				/* BEGINNING OF ACTION: skip-to-end-of-result-assign */
 				{
-#line 1036 "c-parser.act"
+#line 1029 "c-parser.act"
 
 		while (CURRENT_TERMINAL != (C_TOK_EOF)
 			&& CURRENT_TERMINAL != (C_TOK_TERMINATOR)
@@ -2716,7 +2715,7 @@ ZR181(void)
 
 		c_propagating_error = true;
 	
-#line 2721 "c-parser.c"
+#line 2719 "c-parser.c"
 				}
 				/* END OF ACTION: skip-to-end-of-result-assign */
 			}
@@ -2750,13 +2749,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-separator */
 		{
-#line 817 "c-parser.act"
+#line 807 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("','");
 		}
 	
-#line 2761 "c-parser.c"
+#line 2759 "c-parser.c"
 		}
 		/* END OF ACTION: expected-separator */
 	}
@@ -2775,11 +2774,11 @@ ZR149(void)
 		case (C_TOK_C_HIDENTIFIER):
 			/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 			{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI128, c_lexer_string_value(c_current_stream));
 	
-#line 2784 "c-parser.c"
+#line 2782 "c-parser.c"
 			}
 			/* END OF EXTRACT: C-IDENTIFIER */
 			break;
@@ -2805,11 +2804,11 @@ ZR149(void)
 									{
 										/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 										{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI145, c_lexer_string_value(c_current_stream));
 	
-#line 2814 "c-parser.c"
+#line 2812 "c-parser.c"
 										}
 										/* END OF EXTRACT: C-IDENTIFIER */
 										ADVANCE_LEXER;
@@ -2819,11 +2818,11 @@ ZR149(void)
 									{
 										/* BEGINNING OF EXTRACT: SID-IDENTIFIER */
 										{
-#line 177 "c-parser.act"
+#line 170 "c-parser.act"
 
 		nstring_assign(&ZI145, c_lexer_string_value(c_current_stream));
 	
-#line 2828 "c-parser.c"
+#line 2826 "c-parser.c"
 										}
 										/* END OF EXTRACT: SID-IDENTIFIER */
 										ADVANCE_LEXER;
@@ -2842,7 +2841,7 @@ ZR149(void)
 										ADVANCE_LEXER;
 										/* BEGINNING OF ACTION: tuple-ref-type */
 										{
-#line 359 "c-parser.act"
+#line 352 "c-parser.act"
 
 		if (!types_add_typed_name(&c_current_type, c_current_table, &(ZI128),
 			(&ZI145), true)) {
@@ -2851,7 +2850,7 @@ ZR149(void)
 		}
 		nstring_destroy(&(ZI145));
 	
-#line 2856 "c-parser.c"
+#line 2854 "c-parser.c"
 										}
 										/* END OF ACTION: tuple-ref-type */
 									}
@@ -2860,7 +2859,7 @@ ZR149(void)
 									{
 										/* BEGINNING OF ACTION: tuple-type */
 										{
-#line 350 "c-parser.act"
+#line 343 "c-parser.act"
 
 		if (!types_add_typed_name(&c_current_type, c_current_table, &(ZI128),
 			(&ZI145), false)) {
@@ -2869,7 +2868,7 @@ ZR149(void)
 		}
 		nstring_destroy(&(ZI145));
 	
-#line 2874 "c-parser.c"
+#line 2872 "c-parser.c"
 										}
 										/* END OF ACTION: tuple-type */
 									}
@@ -2883,27 +2882,27 @@ ZR149(void)
 						{
 							/* BEGINNING OF ACTION: expected-identifier */
 							{
-#line 805 "c-parser.act"
+#line 795 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 2894 "c-parser.c"
+#line 2892 "c-parser.c"
 							}
 							/* END OF ACTION: expected-identifier */
 							/* BEGINNING OF ACTION: destroy-string */
 							{
-#line 892 "c-parser.act"
+#line 885 "c-parser.act"
 
 		nstring_destroy(&(ZI128));
 	
-#line 2903 "c-parser.c"
+#line 2901 "c-parser.c"
 							}
 							/* END OF ACTION: destroy-string */
 							/* BEGINNING OF ACTION: skip-to-end-of-tuple-defn */
 							{
-#line 896 "c-parser.act"
+#line 889 "c-parser.act"
 
 		while (CURRENT_TERMINAL != (C_TOK_EOF)
 			&& CURRENT_TERMINAL != (C_TOK_DEFINE)
@@ -2932,7 +2931,7 @@ ZR149(void)
 
 		c_propagating_error = true;
 	
-#line 2937 "c-parser.c"
+#line 2935 "c-parser.c"
 							}
 							/* END OF ACTION: skip-to-end-of-tuple-defn */
 						}
@@ -2945,11 +2944,11 @@ ZR149(void)
 				{
 					/* BEGINNING OF ACTION: tuple-name */
 					{
-#line 368 "c-parser.act"
+#line 361 "c-parser.act"
 
 		types_add_name(&c_current_type, c_current_table, &(ZI128), false);
 	
-#line 2954 "c-parser.c"
+#line 2952 "c-parser.c"
 					}
 					/* END OF ACTION: tuple-name */
 				}
@@ -2963,18 +2962,18 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-identifier */
 		{
-#line 805 "c-parser.act"
+#line 795 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 2974 "c-parser.c"
+#line 2972 "c-parser.c"
 		}
 		/* END OF ACTION: expected-identifier */
 		/* BEGINNING OF ACTION: skip-to-end-of-tuple-defn */
 		{
-#line 896 "c-parser.act"
+#line 889 "c-parser.act"
 
 		while (CURRENT_TERMINAL != (C_TOK_EOF)
 			&& CURRENT_TERMINAL != (C_TOK_DEFINE)
@@ -3003,7 +3002,7 @@ ZL1:;
 
 		c_propagating_error = true;
 	
-#line 3008 "c-parser.c"
+#line 3006 "c-parser.c"
 		}
 		/* END OF ACTION: skip-to-end-of-tuple-defn */
 	}
@@ -3029,13 +3028,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-terminator */
 		{
-#line 841 "c-parser.act"
+#line 831 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("';'");
 		}
 	
-#line 3040 "c-parser.c"
+#line 3038 "c-parser.c"
 		}
 		/* END OF ACTION: expected-terminator */
 	}
@@ -3057,11 +3056,11 @@ ZR188(void)
 				{
 					/* BEGINNING OF EXTRACT: C-IDENTIFIER */
 					{
-#line 173 "c-parser.act"
+#line 166 "c-parser.act"
 
 		nstring_assign(&ZI109, c_lexer_string_value(c_current_stream));
 	
-#line 3066 "c-parser.c"
+#line 3064 "c-parser.c"
 					}
 					/* END OF EXTRACT: C-IDENTIFIER */
 					ADVANCE_LEXER;
@@ -3071,11 +3070,11 @@ ZR188(void)
 				{
 					/* BEGINNING OF EXTRACT: SID-IDENTIFIER */
 					{
-#line 177 "c-parser.act"
+#line 170 "c-parser.act"
 
 		nstring_assign(&ZI109, c_lexer_string_value(c_current_stream));
 	
-#line 3080 "c-parser.c"
+#line 3078 "c-parser.c"
 					}
 					/* END OF EXTRACT: SID-IDENTIFIER */
 					ADVANCE_LEXER;
@@ -3088,7 +3087,7 @@ ZR188(void)
 		/* END OF INLINE: c-parse-grammar::identifier */
 		/* BEGINNING OF ACTION: set-terminal */
 		{
-#line 578 "c-parser.act"
+#line 571 "c-parser.act"
 
 		c_current_entry = table_get_basic(c_current_table, (&ZI109));
 		if (c_current_entry == NULL) {
@@ -3108,7 +3107,7 @@ ZR188(void)
 		}
 		nstring_destroy(&(ZI109));
 	
-#line 3113 "c-parser.c"
+#line 3111 "c-parser.c"
 		}
 		/* END OF ACTION: set-terminal */
 		ZR147 ();
@@ -3129,7 +3128,7 @@ ZR188(void)
 				}
 				/* BEGINNING OF ACTION: x-set-terminal */
 				{
-#line 636 "c-parser.act"
+#line 592 "c-parser.act"
 
 		if (c_current_entry) {
 			BasicT     *basic   = entry_get_basic(c_current_entry);
@@ -3181,7 +3180,7 @@ ZR188(void)
 			c_code_deallocate((ZI170));
 		}
 	
-#line 3186 "c-parser.c"
+#line 3184 "c-parser.c"
 				}
 				/* END OF ACTION: x-set-terminal */
 				ZR223 ();
@@ -3195,18 +3194,18 @@ ZR188(void)
 			{
 				/* BEGINNING OF ACTION: expected-code */
 				{
-#line 859 "c-parser.act"
+#line 849 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("code block");
 		}
 	
-#line 3206 "c-parser.c"
+#line 3204 "c-parser.c"
 				}
 				/* END OF ACTION: expected-code */
 				/* BEGINNING OF ACTION: skip-to-end-of-terminal */
 				{
-#line 1061 "c-parser.act"
+#line 1054 "c-parser.act"
 
 		while (CURRENT_TERMINAL != (C_TOK_EOF)
 			&& CURRENT_TERMINAL != (C_TOK_TERMINATOR)
@@ -3230,7 +3229,7 @@ ZR188(void)
 
 		c_propagating_error = true;
 	
-#line 3235 "c-parser.c"
+#line 3233 "c-parser.c"
 				}
 				/* END OF ACTION: skip-to-end-of-terminal */
 			}
@@ -3258,11 +3257,11 @@ ZL2_130:;
 			}
 			/* BEGINNING OF ACTION: skip-recover */
 			{
-#line 1110 "c-parser.act"
+#line 1102 "c-parser.act"
 
 		c_propagating_error = false;
 	
-#line 3267 "c-parser.c"
+#line 3265 "c-parser.c"
 			}
 			/* END OF ACTION: skip-recover */
 			/* BEGINNING OF INLINE: c-parse-grammar::map-list */
@@ -3295,11 +3294,11 @@ ZR147(void)
 			}
 			/* BEGINNING OF ACTION: save-tuple */
 			{
-#line 338 "c-parser.act"
+#line 330 "c-parser.act"
 
 		types_assign(&c_saved_type, &c_current_type);
 	
-#line 3304 "c-parser.c"
+#line 3302 "c-parser.c"
 			}
 			/* END OF ACTION: save-tuple */
 			ZR163 ();
@@ -3314,12 +3313,12 @@ ZR147(void)
 		{
 			/* BEGINNING OF ACTION: null-type */
 			{
-#line 343 "c-parser.act"
+#line 334 "c-parser.act"
 
 		types_init(&c_saved_type);
 		types_init(&c_current_type);
 	
-#line 3324 "c-parser.c"
+#line 3322 "c-parser.c"
 			}
 			/* END OF ACTION: null-type */
 		}
@@ -3347,11 +3346,11 @@ ZL2_164:;
 			}
 			/* BEGINNING OF ACTION: skip-recover */
 			{
-#line 1110 "c-parser.act"
+#line 1102 "c-parser.act"
 
 		c_propagating_error = false;
 	
-#line 3356 "c-parser.c"
+#line 3354 "c-parser.c"
 			}
 			/* END OF ACTION: skip-recover */
 			/* BEGINNING OF INLINE: c-parse-grammar::assignment-list */
@@ -3384,11 +3383,11 @@ ZL2_172:;
 			}
 			/* BEGINNING OF ACTION: skip-recover */
 			{
-#line 1110 "c-parser.act"
+#line 1102 "c-parser.act"
 
 		c_propagating_error = false;
 	
-#line 3393 "c-parser.c"
+#line 3391 "c-parser.c"
 			}
 			/* END OF ACTION: skip-recover */
 			/* BEGINNING OF INLINE: c-parse-grammar::param-assign-list */
@@ -3427,13 +3426,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-define */
 		{
-#line 853 "c-parser.act"
+#line 843 "c-parser.act"
 
 		if (!c_propagating_error) {
 			err_expected("'='");
 		}
 	
-#line 3438 "c-parser.c"
+#line 3436 "c-parser.c"
 		}
 		/* END OF ACTION: expected-define */
 	}
@@ -3441,9 +3440,9 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1120 "c-parser.act"
+#line 1112 "c-parser.act"
 
 
-#line 3449 "c-parser.c"
+#line 3447 "c-parser.c"
 
 /* END OF FILE */

--- a/sid/src/lang-c/c-parser.h
+++ b/sid/src/lang-c/c-parser.h
@@ -9,8 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 150 "c-parser.act"
-
+#line 119 "c-parser.act"
 
 
 	/*
@@ -32,20 +31,20 @@
 	#include "c-lexer.h"
 	#include "c-out-info.h"
 
-	CLexerStreamT *c_current_stream;
-	COutputInfoT  *c_current_out_info;
-	TableT        *c_current_table;
+	extern CLexerStreamT *c_current_stream;
+	extern COutputInfoT  *c_current_out_info;
+	extern TableT        *c_current_table;
 
-#line 41 "c-parser.h"
+#line 39 "c-parser.h"
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
 extern void c_parse_grammar(void);
 /* BEGINNING OF TRAILER */
 
-#line 1122 "c-parser.act"
+#line 1114 "c-parser.act"
 
 
-#line 51 "c-parser.h"
+#line 49 "c-parser.h"
 
 /* END OF FILE */

--- a/sid/src/lexer.h
+++ b/sid/src/lexer.h
@@ -20,7 +20,7 @@
 #include <exds/istream.h>
 #include  "lexi_lexer.h"
 
-struct lexi_state lexi_current_state ;
+extern struct lexi_state lexi_current_state ;
 
 /*
  * Note:
@@ -93,6 +93,6 @@ int read_builtin(void);
 int lexi_unknown_token(int c0);
 
 /* XXX remove once lexi provides opaque pointers */
-LexerStreamT *lexer_stream;
+extern LexerStreamT *lexer_stream;
 
 #endif /* !defined (H_LEXER) */

--- a/sid/src/parser.act
+++ b/sid/src/parser.act
@@ -176,7 +176,7 @@
 	#include "grammar.h"
 	#include "lexer.h"
 
-	LexerStreamT *  sid_current_stream;
+	extern LexerStreamT *  sid_current_stream;
 
 @};
 

--- a/sid/src/parser.c
+++ b/sid/src/parser.c
@@ -9,8 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 75 "parser.act"
-
+#line 36 "parser.act"
 
 
 	/*
@@ -135,7 +134,7 @@
 			(void *) name, alt, (void *) rule);
 	}
 
-#line 140 "parser.c"
+#line 138 "parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -243,13 +242,13 @@ ZR250(GrammarP sid_current_grammar)
 	{
 		/* BEGINNING OF ACTION: handler */
 		{
-#line 1035 "parser.act"
+#line 1025 "parser.act"
 
 		if (sid_current_entry) {
 			sid_current_alt = alt_create();
 		}
 	
-#line 254 "parser.c"
+#line 252 "parser.c"
 		}
 		/* END OF ACTION: handler */
 		ZR248 (sid_current_grammar);
@@ -259,7 +258,7 @@ ZR250(GrammarP sid_current_grammar)
 		}
 		/* BEGINNING OF ACTION: x-handler */
 		{
-#line 1055 "parser.act"
+#line 1031 "parser.act"
 
 		if (sid_current_entry && sid_current_alt) {
 			if (types_check_names(rule_result(sid_current_rule),
@@ -279,7 +278,7 @@ ZR250(GrammarP sid_current_grammar)
 			}
 		}
 	
-#line 284 "parser.c"
+#line 282 "parser.c"
 		}
 		/* END OF ACTION: x-handler */
 	}
@@ -307,13 +306,13 @@ ZL2_148:;
 			{
 				/* BEGINNING OF ACTION: is-close-tuple-or-skipped-or-eof */
 				{
-#line 2104 "parser.act"
+#line 2097 "parser.act"
 
 		(ZI0) = (CURRENT_TERMINAL == (LEXER_TOK_CLOSE_HTUPLE)
 			|| CURRENT_TERMINAL == (LEXER_TOK_EOF)
 			|| sid_propagating_error);
 	
-#line 318 "parser.c"
+#line 316 "parser.c"
 				}
 				/* END OF ACTION: is-close-tuple-or-skipped-or-eof */
 				if (!ZI0)
@@ -339,13 +338,13 @@ ZL2_148:;
 			{
 				/* BEGINNING OF ACTION: expected-separator */
 				{
-#line 1678 "parser.act"
+#line 1668 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("','");
 		}
 	
-#line 350 "parser.c"
+#line 348 "parser.c"
 				}
 				/* END OF ACTION: expected-separator */
 				/* BEGINNING OF INLINE: sid-parse-grammar::function-type-defn::tuple-defn-list-1 */
@@ -373,17 +372,17 @@ ZR166(GrammarP sid_current_grammar, NStringT *ZO165)
 		{
 			/* BEGINNING OF EXTRACT: BASIC */
 			{
-#line 248 "parser.act"
+#line 241 "parser.act"
 
 		nstring_assign(&ZI165, lexer_string_value(sid_current_stream));
 	
-#line 382 "parser.c"
+#line 380 "parser.c"
 			}
 			/* END OF EXTRACT: BASIC */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: x-basic */
 			{
-#line 350 "parser.act"
+#line 343 "parser.act"
 
 		EntryT *entry = table_get_entry(grammar_table(sid_current_grammar), (&ZI165));
 
@@ -396,7 +395,7 @@ ZR166(GrammarP sid_current_grammar, NStringT *ZO165)
 		}
 
 	
-#line 401 "parser.c"
+#line 399 "parser.c"
 			}
 			/* END OF ACTION: x-basic */
 		}
@@ -405,11 +404,11 @@ ZR166(GrammarP sid_current_grammar, NStringT *ZO165)
 		{
 			/* BEGINNING OF EXTRACT: IDENTIFIER */
 			{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI165, lexer_string_value(sid_current_stream));
 	
-#line 414 "parser.c"
+#line 412 "parser.c"
 			}
 			/* END OF EXTRACT: IDENTIFIER */
 			ADVANCE_LEXER;
@@ -427,10 +426,10 @@ ZL1:;
 ZL0:;
 	/* BEGINNING OF RESULT ASSIGNMENT: StringT */
 	{
-#line 228 "parser.act"
+#line 221 "parser.act"
 
 		nstring_assign(ZO165, (&ZI165));
-	#line 435 "parser.c"
+	#line 433 "parser.c"
 	}
 	/* END OF RESULT ASSIGNMENT: StringT */
 }
@@ -443,7 +442,7 @@ ZR269(GrammarP sid_current_grammar, TypeTupleT *ZI134, TypeTupleT *ZI135)
 		{
 			/* BEGINNING OF ACTION: prod */
 			{
-#line 828 "parser.act"
+#line 812 "parser.act"
 
 		if (sid_current_entry) {
 			KeyT *key;
@@ -550,12 +549,12 @@ ZR269(GrammarP sid_current_grammar, TypeTupleT *ZI134, TypeTupleT *ZI135)
 		sid_external_rule = sid_current_entry;
 		nstring_init(&sid_maximum_scope);
 	
-#line 555 "parser.c"
+#line 553 "parser.c"
 			}
 			/* END OF ACTION: prod */
 			/* BEGINNING OF ACTION: push-scope */
 			{
-#line 941 "parser.act"
+#line 928 "parser.act"
 
 		if (sid_current_entry) {
 			KeyT     *key   = entry_key(sid_current_entry);
@@ -564,7 +563,7 @@ ZR269(GrammarP sid_current_grammar, TypeTupleT *ZI134, TypeTupleT *ZI135)
 			scope_stack_push(&sid_scope_stack, scope);
 		}
 	
-#line 569 "parser.c"
+#line 567 "parser.c"
 			}
 			/* END OF ACTION: push-scope */
 			ZR211 (sid_current_grammar);
@@ -589,13 +588,13 @@ ZR269(GrammarP sid_current_grammar, TypeTupleT *ZI134, TypeTupleT *ZI135)
 				{
 					/* BEGINNING OF ACTION: expected-begin-rule */
 					{
-#line 1762 "parser.act"
+#line 1752 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("'{'");
 		}
 	
-#line 600 "parser.c"
+#line 598 "parser.c"
 					}
 					/* END OF ACTION: expected-begin-rule */
 				}
@@ -610,18 +609,18 @@ ZR269(GrammarP sid_current_grammar, TypeTupleT *ZI134, TypeTupleT *ZI135)
 			}
 			/* BEGINNING OF ACTION: pop-scope */
 			{
-#line 947 "parser.act"
+#line 937 "parser.act"
 
 		if (sid_current_entry) {
 			scope_stack_pop(&sid_scope_stack);
 		}
 	
-#line 621 "parser.c"
+#line 619 "parser.c"
 			}
 			/* END OF ACTION: pop-scope */
 			/* BEGINNING OF ACTION: x-prod */
 			{
-#line 932 "parser.act"
+#line 919 "parser.act"
 
 		if (sid_current_entry) {
 			nstring_assign(rule_maximum_scope(sid_current_rule),
@@ -630,7 +629,7 @@ ZR269(GrammarP sid_current_grammar, TypeTupleT *ZI134, TypeTupleT *ZI135)
 			nstring_destroy(&sid_maximum_scope);
 		}
 	
-#line 635 "parser.c"
+#line 633 "parser.c"
 			}
 			/* END OF ACTION: x-prod */
 			ZR247 (sid_current_grammar);
@@ -644,7 +643,7 @@ ZR269(GrammarP sid_current_grammar, TypeTupleT *ZI134, TypeTupleT *ZI135)
 		{
 			/* BEGINNING OF ACTION: x-rule */
 			{
-#line 754 "parser.act"
+#line 741 "parser.act"
 
 		if (sid_current_entry) {
 			KeyT       *key     = entry_key(sid_current_entry);
@@ -715,7 +714,7 @@ ZR269(GrammarP sid_current_grammar, TypeTupleT *ZI134, TypeTupleT *ZI135)
 			types_destroy((ZI135));
 		}
 	
-#line 720 "parser.c"
+#line 718 "parser.c"
 			}
 			/* END OF ACTION: x-rule */
 			ADVANCE_LEXER;
@@ -740,7 +739,7 @@ ZR252(GrammarP sid_current_grammar)
 		{
 			/* BEGINNING OF ACTION: empty-alt */
 			{
-#line 992 "parser.act"
+#line 961 "parser.act"
 
 		sid_num_alternatives++;
 		if (sid_num_alternatives == ALT_LIMIT) {
@@ -767,7 +766,7 @@ ZR252(GrammarP sid_current_grammar)
 			}
 		}
 	
-#line 772 "parser.c"
+#line 770 "parser.c"
 			}
 			/* END OF ACTION: empty-alt */
 			ADVANCE_LEXER;
@@ -783,7 +782,7 @@ ZR252(GrammarP sid_current_grammar)
 		{
 			/* BEGINNING OF ACTION: non-empty-alt */
 			{
-#line 1009 "parser.act"
+#line 988 "parser.act"
 
 		sid_num_alternatives++;
 		if (sid_num_alternatives == ALT_LIMIT) {
@@ -800,7 +799,7 @@ ZR252(GrammarP sid_current_grammar)
 			sid_current_alt = alt_create();
 		}
 	
-#line 805 "parser.c"
+#line 803 "parser.c"
 			}
 			/* END OF ACTION: non-empty-alt */
 			ZR248 (sid_current_grammar);
@@ -810,7 +809,7 @@ ZR252(GrammarP sid_current_grammar)
 			}
 			/* BEGINNING OF ACTION: x-non-empty-alt */
 			{
-#line 1029 "parser.act"
+#line 1005 "parser.act"
 
 		if (sid_current_entry && sid_current_alt) {
 			if (types_check_names(rule_result(sid_current_rule),
@@ -830,7 +829,7 @@ ZR252(GrammarP sid_current_grammar)
 			}
 		}
 	
-#line 835 "parser.c"
+#line 833 "parser.c"
 			}
 			/* END OF ACTION: x-non-empty-alt */
 		}
@@ -845,18 +844,18 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-alternative */
 		{
-#line 1780 "parser.act"
+#line 1770 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("alternative");
 		}
 	
-#line 856 "parser.c"
+#line 854 "parser.c"
 		}
 		/* END OF ACTION: expected-alternative */
 		/* BEGINNING OF ACTION: skip-to-end-of-alternative */
 		{
-#line 2000 "parser.act"
+#line 1993 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_ALT_HSEP)
@@ -881,16 +880,16 @@ ZL1:;
 
 		sid_propagating_error = true;
 	
-#line 886 "parser.c"
+#line 884 "parser.c"
 		}
 		/* END OF ACTION: skip-to-end-of-alternative */
 		/* BEGINNING OF ACTION: skip-recover */
 		{
-#line 2095 "parser.act"
+#line 2087 "parser.act"
 
 		sid_propagating_error = false;
 	
-#line 895 "parser.c"
+#line 893 "parser.c"
 		}
 		/* END OF ACTION: skip-recover */
 	}
@@ -933,11 +932,11 @@ ZR259(GrammarP sid_current_grammar)
 		case (LEXER_TOK_IDENTIFIER):
 			/* BEGINNING OF EXTRACT: IDENTIFIER */
 			{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI163, lexer_string_value(sid_current_stream));
 	
-#line 942 "parser.c"
+#line 940 "parser.c"
 			}
 			/* END OF EXTRACT: IDENTIFIER */
 			break;
@@ -965,25 +964,25 @@ ZR259(GrammarP sid_current_grammar)
 
 					/* BEGINNING OF ACTION: init-tuple */
 					{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI134));
 	
-#line 974 "parser.c"
+#line 972 "parser.c"
 					}
 					/* END OF ACTION: init-tuple */
 					/* BEGINNING OF ACTION: init-tuple */
 					{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI135));
 	
-#line 983 "parser.c"
+#line 981 "parser.c"
 					}
 					/* END OF ACTION: init-tuple */
 					/* BEGINNING OF ACTION: rule */
 					{
-#line 736 "parser.act"
+#line 728 "parser.act"
 
 		sid_current_entry = scope_stack_add_rule(sid_current_scope,
 			grammar_table(sid_current_grammar), &(ZI163), sid_enclosing_rule,
@@ -995,7 +994,7 @@ ZR259(GrammarP sid_current_grammar)
 			nstring_destroy(&(ZI163));
 		}
 	
-#line 1000 "parser.c"
+#line 998 "parser.c"
 					}
 					/* END OF ACTION: rule */
 					ZR269 (sid_current_grammar, &ZI134, &ZI135);
@@ -1013,27 +1012,27 @@ ZR259(GrammarP sid_current_grammar)
 			{
 				/* BEGINNING OF ACTION: expected-other-defn */
 				{
-#line 1786 "parser.act"
+#line 1776 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("rule declaration or rule or non local name definition");
 		}
 	
-#line 1024 "parser.c"
+#line 1022 "parser.c"
 				}
 				/* END OF ACTION: expected-other-defn */
 				/* BEGINNING OF ACTION: destroy-string */
 				{
-#line 1831 "parser.act"
+#line 1824 "parser.act"
 
 		nstring_destroy(&(ZI163));
 	
-#line 1033 "parser.c"
+#line 1031 "parser.c"
 				}
 				/* END OF ACTION: destroy-string */
 				/* BEGINNING OF ACTION: skip-to-end-of-other-defn */
 				{
-#line 2025 "parser.act"
+#line 2018 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -1057,7 +1056,7 @@ ZR259(GrammarP sid_current_grammar)
 
 		sid_propagating_error = true;
 	
-#line 1062 "parser.c"
+#line 1060 "parser.c"
 				}
 				/* END OF ACTION: skip-to-end-of-other-defn */
 			}
@@ -1082,11 +1081,11 @@ ZR179(GrammarP sid_current_grammar, TypeTupleT *ZO138)
 	{
 		/* BEGINNING OF ACTION: current-tuple */
 		{
-#line 373 "parser.act"
+#line 365 "parser.act"
 
 		sid_current_pred_id = false;
 	
-#line 1091 "parser.c"
+#line 1089 "parser.c"
 		}
 		/* END OF ACTION: current-tuple */
 		ZR201 (sid_current_grammar);
@@ -1096,11 +1095,11 @@ ZR179(GrammarP sid_current_grammar, TypeTupleT *ZO138)
 		}
 		/* BEGINNING OF ACTION: init-tuple */
 		{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI138));
 	
-#line 1105 "parser.c"
+#line 1103 "parser.c"
 		}
 		/* END OF ACTION: init-tuple */
 		ZR187 (sid_current_grammar, &ZI138);
@@ -1110,11 +1109,11 @@ ZR179(GrammarP sid_current_grammar, TypeTupleT *ZO138)
 		}
 		/* BEGINNING OF ACTION: skip-recover */
 		{
-#line 2095 "parser.act"
+#line 2087 "parser.act"
 
 		sid_propagating_error = false;
 	
-#line 1119 "parser.c"
+#line 1117 "parser.c"
 		}
 		/* END OF ACTION: skip-recover */
 		ZR202 (sid_current_grammar);
@@ -1130,7 +1129,7 @@ ZL1:;
 ZL0:;
 	/* BEGINNING OF RESULT ASSIGNMENT: TypeTupleT */
 	{
-#line 232 "parser.act"
+#line 225 "parser.act"
 
 		ZO138->head = ZI138.head;
 
@@ -1139,7 +1138,7 @@ ZL0:;
 		} else {
 			ZO138->tail= ZI138.tail ;
 		}
-	#line 1144 "parser.c"
+	#line 1142 "parser.c"
 	}
 	/* END OF RESULT ASSIGNMENT: TypeTupleT */
 }
@@ -1184,11 +1183,11 @@ ZR191(GrammarP sid_current_grammar, TypeTupleT *ZO138)
 	{
 		/* BEGINNING OF ACTION: current-tuple */
 		{
-#line 373 "parser.act"
+#line 365 "parser.act"
 
 		sid_current_pred_id = false;
 	
-#line 1193 "parser.c"
+#line 1191 "parser.c"
 		}
 		/* END OF ACTION: current-tuple */
 		ZR201 (sid_current_grammar);
@@ -1198,11 +1197,11 @@ ZR191(GrammarP sid_current_grammar, TypeTupleT *ZO138)
 		}
 		/* BEGINNING OF ACTION: init-tuple */
 		{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI138));
 	
-#line 1207 "parser.c"
+#line 1205 "parser.c"
 		}
 		/* END OF ACTION: init-tuple */
 		ZR199 (sid_current_grammar, &ZI138);
@@ -1212,11 +1211,11 @@ ZR191(GrammarP sid_current_grammar, TypeTupleT *ZO138)
 		}
 		/* BEGINNING OF ACTION: skip-recover */
 		{
-#line 2095 "parser.act"
+#line 2087 "parser.act"
 
 		sid_propagating_error = false;
 	
-#line 1221 "parser.c"
+#line 1219 "parser.c"
 		}
 		/* END OF ACTION: skip-recover */
 		ZR202 (sid_current_grammar);
@@ -1232,7 +1231,7 @@ ZL1:;
 ZL0:;
 	/* BEGINNING OF RESULT ASSIGNMENT: TypeTupleT */
 	{
-#line 232 "parser.act"
+#line 225 "parser.act"
 
 		ZO138->head = ZI138.head;
 
@@ -1241,7 +1240,7 @@ ZL0:;
 		} else {
 			ZO138->tail= ZI138.tail ;
 		}
-	#line 1246 "parser.c"
+	#line 1244 "parser.c"
 	}
 	/* END OF RESULT ASSIGNMENT: TypeTupleT */
 }
@@ -1261,7 +1260,7 @@ ZR241(GrammarP sid_current_grammar)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: save */
 			{
-#line 1058 "parser.act"
+#line 1051 "parser.act"
 
 		(ZI172)      = sid_current_entry;
 		(ZI75)       = sid_current_rule;
@@ -1286,7 +1285,7 @@ ZR241(GrammarP sid_current_grammar)
 			sid_current_entry = NULL;
 		}
 	
-#line 1291 "parser.c"
+#line 1289 "parser.c"
 			}
 			/* END OF ACTION: save */
 			ZR239 (sid_current_grammar);
@@ -1296,7 +1295,7 @@ ZR241(GrammarP sid_current_grammar)
 			}
 			/* BEGINNING OF ACTION: restore */
 			{
-#line 1083 "parser.act"
+#line 1076 "parser.act"
 
 		if ((ZI172) && (ZI243)) {
 			rule_compute_result_intersect(sid_current_rule);
@@ -1310,7 +1309,7 @@ ZR241(GrammarP sid_current_grammar)
 		sid_current_rule  = (ZI75);
 		sid_current_entry = (ZI172);
 	
-#line 1315 "parser.c"
+#line 1313 "parser.c"
 			}
 			/* END OF ACTION: restore */
 			ZR246 (sid_current_grammar);
@@ -1331,11 +1330,11 @@ ZR241(GrammarP sid_current_grammar)
 			}
 			/* BEGINNING OF ACTION: skip-recover */
 			{
-#line 2095 "parser.act"
+#line 2087 "parser.act"
 
 		sid_propagating_error = false;
 	
-#line 1340 "parser.c"
+#line 1338 "parser.c"
 			}
 			/* END OF ACTION: skip-recover */
 		}
@@ -1367,24 +1366,24 @@ ZR160(GrammarP sid_current_grammar)
 
 					/* BEGINNING OF EXTRACT: IDENTIFIER */
 					{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI163, lexer_string_value(sid_current_stream));
 	
-#line 1376 "parser.c"
+#line 1374 "parser.c"
 					}
 					/* END OF EXTRACT: IDENTIFIER */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: add-type */
 					{
-#line 264 "parser.act"
+#line 257 "parser.act"
 
 		if (table_add_type(grammar_table(sid_current_grammar), &(ZI163), false) == NULL) {
 			err_redeclared("type", (&ZI163));
 			nstring_destroy(&(ZI163));
 		}
 	
-#line 1389 "parser.c"
+#line 1387 "parser.c"
 					}
 					/* END OF ACTION: add-type */
 				}
@@ -1398,11 +1397,11 @@ ZR160(GrammarP sid_current_grammar)
 					case (LEXER_TOK_IDENTIFIER):
 						/* BEGINNING OF EXTRACT: IDENTIFIER */
 						{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI163, lexer_string_value(sid_current_stream));
 	
-#line 1407 "parser.c"
+#line 1405 "parser.c"
 						}
 						/* END OF EXTRACT: IDENTIFIER */
 						break;
@@ -1412,14 +1411,14 @@ ZR160(GrammarP sid_current_grammar)
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: i-add-type */
 					{
-#line 271 "parser.act"
+#line 264 "parser.act"
 
 		if (table_add_type(grammar_table(sid_current_grammar), &(ZI163), true) == NULL) {
 			err_redeclared("type", (&ZI163));
 			nstring_destroy(&(ZI163));
 		}
 	
-#line 1424 "parser.c"
+#line 1422 "parser.c"
 					}
 					/* END OF ACTION: i-add-type */
 				}
@@ -1432,13 +1431,13 @@ ZR160(GrammarP sid_current_grammar)
 			{
 				/* BEGINNING OF ACTION: expected-identifier */
 				{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 1443 "parser.c"
+#line 1441 "parser.c"
 				}
 				/* END OF ACTION: expected-identifier */
 			}
@@ -1493,14 +1492,14 @@ ZR211(GrammarP sid_current_grammar)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: save-scope */
 			{
-#line 950 "parser.act"
+#line 943 "parser.act"
 
 		(ZI172) = sid_current_entry;
 		(ZI75)  = sid_enclosing_rule;
 
 		sid_enclosing_rule = sid_current_rule;
 	
-#line 1505 "parser.c"
+#line 1503 "parser.c"
 			}
 			/* END OF ACTION: save-scope */
 			ZR177 (sid_current_grammar);
@@ -1510,7 +1509,7 @@ ZR211(GrammarP sid_current_grammar)
 			}
 			/* BEGINNING OF ACTION: restore-scope */
 			{
-#line 957 "parser.act"
+#line 950 "parser.act"
 
 		sid_current_entry  = (ZI172);
 		sid_current_rule   = sid_enclosing_rule;
@@ -1521,7 +1520,7 @@ ZR211(GrammarP sid_current_grammar)
 
 		nstring_init(&sid_maximum_scope);
 	
-#line 1526 "parser.c"
+#line 1524 "parser.c"
 			}
 			/* END OF ACTION: restore-scope */
 			/* BEGINNING OF INLINE: 213 */
@@ -1540,13 +1539,13 @@ ZR211(GrammarP sid_current_grammar)
 				{
 					/* BEGINNING OF ACTION: expected-end-scope */
 					{
-#line 1732 "parser.act"
+#line 1722 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("']'");
 		}
 	
-#line 1551 "parser.c"
+#line 1549 "parser.c"
 					}
 					/* END OF ACTION: expected-end-scope */
 				}
@@ -1586,13 +1585,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-arrow */
 		{
-#line 1696 "parser.act"
+#line 1686 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("'->'");
 		}
 	
-#line 1597 "parser.c"
+#line 1595 "parser.c"
 		}
 		/* END OF ACTION: expected-arrow */
 	}
@@ -1608,17 +1607,17 @@ ZR181(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 
 			/* BEGINNING OF EXTRACT: IDENTIFIER */
 			{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI163, lexer_string_value(sid_current_stream));
 	
-#line 1617 "parser.c"
+#line 1615 "parser.c"
 			}
 			/* END OF EXTRACT: IDENTIFIER */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: add-name */
 			{
-#line 416 "parser.act"
+#line 404 "parser.act"
 
 		NStringT scope;
 		EntryT *non_local_entry;
@@ -1658,7 +1657,7 @@ ZR181(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 			types_add_name((ZI138), grammar_table(sid_current_grammar), &(ZI163), false);
 		}
 	
-#line 1663 "parser.c"
+#line 1661 "parser.c"
 			}
 			/* END OF ACTION: add-name */
 		}
@@ -1668,14 +1667,14 @@ ZR181(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: add-void */
 			{
-#line 546 "parser.act"
+#line 536 "parser.act"
 
 		EntryT *entry;
 
 		entry = table_add_generated_name(grammar_table(sid_current_grammar));
 		types_add_name_entry((ZI138), entry);
 	
-#line 1680 "parser.c"
+#line 1678 "parser.c"
 			}
 			/* END OF ACTION: add-void */
 		}
@@ -1685,7 +1684,7 @@ ZR181(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: add-pred */
 			{
-#line 539 "parser.act"
+#line 527 "parser.act"
 
 		if (sid_current_pred_id) {
 			error_posn(ERR_SERIOUS, lexer_stream_name(sid_current_stream), (int) lexer_stream_line(sid_current_stream),
@@ -1694,7 +1693,7 @@ ZR181(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 		sid_current_pred_id = true;
 		types_add_name_entry((ZI138), grammar_get_predicate_id(sid_current_grammar));
 	
-#line 1699 "parser.c"
+#line 1697 "parser.c"
 			}
 			/* END OF ACTION: add-pred */
 		}
@@ -1711,11 +1710,11 @@ ZR181(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 					case (LEXER_TOK_IDENTIFIER):
 						/* BEGINNING OF EXTRACT: IDENTIFIER */
 						{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI163, lexer_string_value(sid_current_stream));
 	
-#line 1720 "parser.c"
+#line 1718 "parser.c"
 						}
 						/* END OF EXTRACT: IDENTIFIER */
 						break;
@@ -1725,7 +1724,7 @@ ZR181(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: add-var */
 					{
-#line 497 "parser.act"
+#line 485 "parser.act"
 
 		NStringT scope;
 		EntryT *non_local_entry;
@@ -1767,7 +1766,7 @@ ZR181(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 			types_add_name((ZI138), grammar_table(sid_current_grammar), &(ZI163), false);
 		}
 	
-#line 1772 "parser.c"
+#line 1770 "parser.c"
 					}
 					/* END OF ACTION: add-var */
 				}
@@ -1776,13 +1775,13 @@ ZR181(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 				{
 					/* BEGINNING OF ACTION: expected-identifier */
 					{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 1787 "parser.c"
+#line 1785 "parser.c"
 					}
 					/* END OF ACTION: expected-identifier */
 				}
@@ -1801,18 +1800,18 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-lhs-name */
 		{
-#line 1708 "parser.act"
+#line 1698 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier, '?' or '!'");
 		}
 	
-#line 1812 "parser.c"
+#line 1810 "parser.c"
 		}
 		/* END OF ACTION: expected-lhs-name */
 		/* BEGINNING OF ACTION: skip-to-end-of-lhs-name */
 		{
-#line 1906 "parser.act"
+#line 1899 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -1834,7 +1833,7 @@ ZL1:;
 
 		sid_propagating_error = true;
 	
-#line 1839 "parser.c"
+#line 1837 "parser.c"
 		}
 		/* END OF ACTION: skip-to-end-of-lhs-name */
 	}
@@ -1855,11 +1854,11 @@ ZL2_177:;
 		}
 		/* BEGINNING OF ACTION: skip-recover */
 		{
-#line 2095 "parser.act"
+#line 2087 "parser.act"
 
 		sid_propagating_error = false;
 	
-#line 1864 "parser.c"
+#line 1862 "parser.c"
 		}
 		/* END OF ACTION: skip-recover */
 		/* BEGINNING OF INLINE: 278 */
@@ -1867,13 +1866,13 @@ ZL2_177:;
 			{
 				/* BEGINNING OF ACTION: is-blt-entry-or-end-scope-or-eof */
 				{
-#line 2098 "parser.act"
+#line 2091 "parser.act"
 
 		(ZI0) = (CURRENT_TERMINAL == (LEXER_TOK_EOF)
 			|| CURRENT_TERMINAL == (LEXER_TOK_END_HSCOPE)
 			|| CURRENT_TERMINAL == (LEXER_TOK_BLT_HENTRY));
 	
-#line 1878 "parser.c"
+#line 1876 "parser.c"
 				}
 				/* END OF ACTION: is-blt-entry-or-end-scope-or-eof */
 				if (!ZI0)
@@ -1902,18 +1901,18 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-production-defn */
 		{
-#line 1792 "parser.act"
+#line 1782 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("rule declaration or definition, or action declaration");
 		}
 	
-#line 1913 "parser.c"
+#line 1911 "parser.c"
 		}
 		/* END OF ACTION: expected-production-defn */
 		/* BEGINNING OF ACTION: skip-to-end-of-production-defn */
 		{
-#line 2049 "parser.act"
+#line 2042 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -1937,16 +1936,16 @@ ZL1:;
 
 		sid_propagating_error = true;
 	
-#line 1942 "parser.c"
+#line 1940 "parser.c"
 		}
 		/* END OF ACTION: skip-to-end-of-production-defn */
 		/* BEGINNING OF ACTION: skip-recover */
 		{
-#line 2095 "parser.act"
+#line 2087 "parser.act"
 
 		sid_propagating_error = false;
 	
-#line 1951 "parser.c"
+#line 1949 "parser.c"
 		}
 		/* END OF ACTION: skip-recover */
 		/* BEGINNING OF INLINE: 279 */
@@ -1954,13 +1953,13 @@ ZL1:;
 			{
 				/* BEGINNING OF ACTION: is-blt-entry-or-end-scope-or-eof */
 				{
-#line 2098 "parser.act"
+#line 2091 "parser.act"
 
 		(ZI0) = (CURRENT_TERMINAL == (LEXER_TOK_EOF)
 			|| CURRENT_TERMINAL == (LEXER_TOK_END_HSCOPE)
 			|| CURRENT_TERMINAL == (LEXER_TOK_BLT_HENTRY));
 	
-#line 1965 "parser.c"
+#line 1963 "parser.c"
 				}
 				/* END OF ACTION: is-blt-entry-or-end-scope-or-eof */
 				if (!ZI0)
@@ -1989,12 +1988,12 @@ sid_parse_grammar(GrammarP sid_current_grammar)
 	{
 		/* BEGINNING OF ACTION: init */
 		{
-#line 256 "parser.act"
+#line 247 "parser.act"
 
 		scope_stack_init(&sid_scope_stack);
 		scope_stack_init(&sid_global_scope);
 	
-#line 1999 "parser.c"
+#line 1997 "parser.c"
 		}
 		/* END OF ACTION: init */
 		/* BEGINNING OF INLINE: 285 */
@@ -2013,13 +2012,13 @@ sid_parse_grammar(GrammarP sid_current_grammar)
 			{
 				/* BEGINNING OF ACTION: expected-blt-types */
 				{
-#line 1798 "parser.act"
+#line 1788 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("'%types%'");
 		}
 	
-#line 2024 "parser.c"
+#line 2022 "parser.c"
 				}
 				/* END OF ACTION: expected-blt-types */
 			}
@@ -2047,13 +2046,13 @@ sid_parse_grammar(GrammarP sid_current_grammar)
 			{
 				/* BEGINNING OF ACTION: expected-blt-terminals */
 				{
-#line 1804 "parser.act"
+#line 1794 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("'%terminals%'");
 		}
 	
-#line 2058 "parser.c"
+#line 2056 "parser.c"
 				}
 				/* END OF ACTION: expected-blt-terminals */
 			}
@@ -2067,14 +2066,14 @@ sid_parse_grammar(GrammarP sid_current_grammar)
 		}
 		/* BEGINNING OF ACTION: x-terminals */
 		{
-#line 347 "parser.act"
+#line 336 "parser.act"
 
 		unsigned max_terminal = grammar_max_terminal(sid_current_grammar);
 
 		bitvec_set_size(max_terminal);
 		sid_finished_terminals = true;
 	
-#line 2079 "parser.c"
+#line 2077 "parser.c"
 		}
 		/* END OF ACTION: x-terminals */
 		/* BEGINNING OF INLINE: 287 */
@@ -2093,13 +2092,13 @@ sid_parse_grammar(GrammarP sid_current_grammar)
 			{
 				/* BEGINNING OF ACTION: expected-blt-productions */
 				{
-#line 1810 "parser.act"
+#line 1800 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("'%productions%'");
 		}
 	
-#line 2104 "parser.c"
+#line 2102 "parser.c"
 				}
 				/* END OF ACTION: expected-blt-productions */
 			}
@@ -2127,13 +2126,13 @@ sid_parse_grammar(GrammarP sid_current_grammar)
 			{
 				/* BEGINNING OF ACTION: expected-blt-entry */
 				{
-#line 1816 "parser.act"
+#line 1806 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("'%entry%'");
 		}
 	
-#line 2138 "parser.c"
+#line 2136 "parser.c"
 				}
 				/* END OF ACTION: expected-blt-entry */
 			}
@@ -2162,13 +2161,13 @@ sid_parse_grammar(GrammarP sid_current_grammar)
 			{
 				/* BEGINNING OF ACTION: expected-eof */
 				{
-#line 1822 "parser.act"
+#line 1812 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("end of file");
 		}
 	
-#line 2173 "parser.c"
+#line 2171 "parser.c"
 				}
 				/* END OF ACTION: expected-eof */
 			}
@@ -2181,11 +2180,11 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: unhandled-syntax-error */
 		{
-#line 1642 "parser.act"
+#line 1634 "parser.act"
 
 		UNREACHED;
 	
-#line 2190 "parser.c"
+#line 2188 "parser.c"
 		}
 		/* END OF ACTION: unhandled-syntax-error */
 	}
@@ -2226,11 +2225,11 @@ ZR153(GrammarP sid_current_grammar, TypeTupleT *ZO138)
 	{
 		/* BEGINNING OF ACTION: init-tuple */
 		{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI138));
 	
-#line 2235 "parser.c"
+#line 2233 "parser.c"
 		}
 		/* END OF ACTION: init-tuple */
 		ZR201 (sid_current_grammar);
@@ -2241,11 +2240,11 @@ ZR153(GrammarP sid_current_grammar, TypeTupleT *ZO138)
 		}
 		/* BEGINNING OF ACTION: skip-recover */
 		{
-#line 2095 "parser.act"
+#line 2087 "parser.act"
 
 		sid_propagating_error = false;
 	
-#line 2250 "parser.c"
+#line 2248 "parser.c"
 		}
 		/* END OF ACTION: skip-recover */
 		ZR202 (sid_current_grammar);
@@ -2261,7 +2260,7 @@ ZL1:;
 ZL0:;
 	/* BEGINNING OF RESULT ASSIGNMENT: TypeTupleT */
 	{
-#line 232 "parser.act"
+#line 225 "parser.act"
 
 		ZO138->head = ZI138.head;
 
@@ -2270,7 +2269,7 @@ ZL0:;
 		} else {
 			ZO138->tail= ZI138.tail ;
 		}
-	#line 2275 "parser.c"
+	#line 2273 "parser.c"
 	}
 	/* END OF RESULT ASSIGNMENT: TypeTupleT */
 }
@@ -2285,17 +2284,17 @@ ZR193(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 
 			/* BEGINNING OF EXTRACT: IDENTIFIER */
 			{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI163, lexer_string_value(sid_current_stream));
 	
-#line 2294 "parser.c"
+#line 2292 "parser.c"
 			}
 			/* END OF EXTRACT: IDENTIFIER */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: add-name */
 			{
-#line 416 "parser.act"
+#line 404 "parser.act"
 
 		NStringT scope;
 		EntryT *non_local_entry;
@@ -2335,7 +2334,7 @@ ZR193(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 			types_add_name((ZI138), grammar_table(sid_current_grammar), &(ZI163), false);
 		}
 	
-#line 2340 "parser.c"
+#line 2338 "parser.c"
 			}
 			/* END OF ACTION: add-name */
 		}
@@ -2352,11 +2351,11 @@ ZR193(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 					case (LEXER_TOK_IDENTIFIER):
 						/* BEGINNING OF EXTRACT: IDENTIFIER */
 						{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI163, lexer_string_value(sid_current_stream));
 	
-#line 2361 "parser.c"
+#line 2359 "parser.c"
 						}
 						/* END OF EXTRACT: IDENTIFIER */
 						break;
@@ -2366,7 +2365,7 @@ ZR193(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: add-ref-name */
 					{
-#line 457 "parser.act"
+#line 445 "parser.act"
 
 		NStringT scope;
 		EntryT *non_local_entry;
@@ -2406,7 +2405,7 @@ ZR193(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 			types_add_name((ZI138), grammar_table(sid_current_grammar), &(ZI163), true);
 		}
 	
-#line 2411 "parser.c"
+#line 2409 "parser.c"
 					}
 					/* END OF ACTION: add-ref-name */
 				}
@@ -2415,18 +2414,18 @@ ZR193(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 				{
 					/* BEGINNING OF ACTION: expected-identifier */
 					{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 2426 "parser.c"
+#line 2424 "parser.c"
 					}
 					/* END OF ACTION: expected-identifier */
 					/* BEGINNING OF ACTION: skip-to-end-of-rhs-name */
 					{
-#line 1928 "parser.act"
+#line 1921 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -2448,7 +2447,7 @@ ZR193(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 
 		sid_propagating_error = true;
 	
-#line 2453 "parser.c"
+#line 2451 "parser.c"
 					}
 					/* END OF ACTION: skip-to-end-of-rhs-name */
 				}
@@ -2467,18 +2466,18 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-rhs-name */
 		{
-#line 1714 "parser.act"
+#line 1704 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier or '&'");
 		}
 	
-#line 2478 "parser.c"
+#line 2476 "parser.c"
 		}
 		/* END OF ACTION: expected-rhs-name */
 		/* BEGINNING OF ACTION: skip-to-end-of-rhs-name */
 		{
-#line 1928 "parser.act"
+#line 1921 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -2500,7 +2499,7 @@ ZL1:;
 
 		sid_propagating_error = true;
 	
-#line 2505 "parser.c"
+#line 2503 "parser.c"
 		}
 		/* END OF ACTION: skip-to-end-of-rhs-name */
 	}
@@ -2522,11 +2521,11 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 			}
 			/* BEGINNING OF ACTION: save-tuple */
 			{
-#line 377 "parser.act"
+#line 369 "parser.act"
 
 		sid_saved_pred_id = sid_current_pred_id;
 	
-#line 2531 "parser.c"
+#line 2529 "parser.c"
 			}
 			/* END OF ACTION: save-tuple */
 			ZR157 (sid_current_grammar);
@@ -2537,7 +2536,7 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 			}
 			/* BEGINNING OF ACTION: rule */
 			{
-#line 736 "parser.act"
+#line 728 "parser.act"
 
 		sid_current_entry = scope_stack_add_rule(sid_current_scope,
 			grammar_table(sid_current_grammar), &(*ZI163), sid_enclosing_rule,
@@ -2549,7 +2548,7 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 			nstring_destroy(&(*ZI163));
 		}
 	
-#line 2554 "parser.c"
+#line 2552 "parser.c"
 			}
 			/* END OF ACTION: rule */
 			ZR269 (sid_current_grammar, &ZI134, &ZI135);
@@ -2571,11 +2570,11 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 					case (LEXER_TOK_IDENTIFIER):
 						/* BEGINNING OF EXTRACT: IDENTIFIER */
 						{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI144, lexer_string_value(sid_current_stream));
 	
-#line 2580 "parser.c"
+#line 2578 "parser.c"
 						}
 						/* END OF EXTRACT: IDENTIFIER */
 						break;
@@ -2585,7 +2584,7 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: non-local */
 					{
-#line 657 "parser.act"
+#line 650 "parser.act"
 
 		(ZI263) = NULL;
 		if (sid_enclosing_rule == NULL || sid_current_scope == &sid_global_scope) {
@@ -2619,7 +2618,7 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 		}
 		nstring_destroy(&(ZI144));
 	
-#line 2624 "parser.c"
+#line 2622 "parser.c"
 					}
 					/* END OF ACTION: non-local */
 					/* BEGINNING OF INLINE: 264 */
@@ -2644,13 +2643,13 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 									{
 										/* BEGINNING OF ACTION: expected-begin-action */
 										{
-#line 1720 "parser.act"
+#line 1710 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("'<'");
 		}
 	
-#line 2655 "parser.c"
+#line 2653 "parser.c"
 										}
 										/* END OF ACTION: expected-begin-action */
 									}
@@ -2666,11 +2665,11 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 										case (LEXER_TOK_IDENTIFIER):
 											/* BEGINNING OF EXTRACT: IDENTIFIER */
 											{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI56, lexer_string_value(sid_current_stream));
 	
-#line 2675 "parser.c"
+#line 2673 "parser.c"
 											}
 											/* END OF EXTRACT: IDENTIFIER */
 											break;
@@ -2680,7 +2679,7 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 										ADVANCE_LEXER;
 										/* BEGINNING OF ACTION: non-local-init */
 										{
-#line 694 "parser.act"
+#line 684 "parser.act"
 
 		EntryT *actionentry;
 
@@ -2724,7 +2723,7 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 		}
 		nstring_destroy(&(ZI56));
 	
-#line 2729 "parser.c"
+#line 2727 "parser.c"
 										}
 										/* END OF ACTION: non-local-init */
 										ZR238 (sid_current_grammar);
@@ -2739,13 +2738,13 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 									{
 										/* BEGINNING OF ACTION: expected-identifier */
 										{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 2750 "parser.c"
+#line 2748 "parser.c"
 										}
 										/* END OF ACTION: expected-identifier */
 									}
@@ -2767,13 +2766,13 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 						{
 							/* BEGINNING OF ACTION: expected-terminator-or-define */
 							{
-#line 1828 "parser.act"
+#line 1818 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("';' or '='");
 		}
 	
-#line 2778 "parser.c"
+#line 2776 "parser.c"
 							}
 							/* END OF ACTION: expected-terminator-or-define */
 						}
@@ -2786,27 +2785,27 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 				{
 					/* BEGINNING OF ACTION: expected-identifier */
 					{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 2797 "parser.c"
+#line 2795 "parser.c"
 					}
 					/* END OF ACTION: expected-identifier */
 					/* BEGINNING OF ACTION: destroy-string */
 					{
-#line 1831 "parser.act"
+#line 1824 "parser.act"
 
 		nstring_destroy(&(*ZI163));
 	
-#line 2806 "parser.c"
+#line 2804 "parser.c"
 					}
 					/* END OF ACTION: destroy-string */
 					/* BEGINNING OF ACTION: skip-to-end-of-other-defn */
 					{
-#line 2025 "parser.act"
+#line 2018 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -2830,7 +2829,7 @@ ZR306(GrammarP sid_current_grammar, NStringT *ZI163)
 
 		sid_propagating_error = true;
 	
-#line 2835 "parser.c"
+#line 2833 "parser.c"
 					}
 					/* END OF ACTION: skip-to-end-of-other-defn */
 				}
@@ -2861,32 +2860,32 @@ ZR308(GrammarP sid_current_grammar)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: init-tuple */
 			{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI214));
 	
-#line 2870 "parser.c"
+#line 2868 "parser.c"
 			}
 			/* END OF ACTION: init-tuple */
 			/* BEGINNING OF ACTION: add-void */
 			{
-#line 546 "parser.act"
+#line 536 "parser.act"
 
 		EntryT *entry;
 
 		entry = table_add_generated_name(grammar_table(sid_current_grammar));
 		types_add_name_entry((&ZI214), entry);
 	
-#line 2882 "parser.c"
+#line 2880 "parser.c"
 			}
 			/* END OF ACTION: add-void */
 			/* BEGINNING OF ACTION: save-tuple */
 			{
-#line 377 "parser.act"
+#line 369 "parser.act"
 
 		sid_saved_pred_id = sid_current_pred_id;
 	
-#line 2891 "parser.c"
+#line 2889 "parser.c"
 			}
 			/* END OF ACTION: save-tuple */
 			ZR234 (sid_current_grammar);
@@ -2904,16 +2903,16 @@ ZR308(GrammarP sid_current_grammar)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: init-tuple */
 			{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI214));
 	
-#line 2913 "parser.c"
+#line 2911 "parser.c"
 			}
 			/* END OF ACTION: init-tuple */
 			/* BEGINNING OF ACTION: add-pred */
 			{
-#line 539 "parser.act"
+#line 527 "parser.act"
 
 		if (sid_current_pred_id) {
 			error_posn(ERR_SERIOUS, lexer_stream_name(sid_current_stream), (int) lexer_stream_line(sid_current_stream),
@@ -2922,16 +2921,16 @@ ZR308(GrammarP sid_current_grammar)
 		sid_current_pred_id = true;
 		types_add_name_entry((&ZI214), grammar_get_predicate_id(sid_current_grammar));
 	
-#line 2927 "parser.c"
+#line 2925 "parser.c"
 			}
 			/* END OF ACTION: add-pred */
 			/* BEGINNING OF ACTION: save-tuple */
 			{
-#line 377 "parser.act"
+#line 369 "parser.act"
 
 		sid_saved_pred_id = sid_current_pred_id;
 	
-#line 2936 "parser.c"
+#line 2934 "parser.c"
 			}
 			/* END OF ACTION: save-tuple */
 			ZR234 (sid_current_grammar);
@@ -2948,20 +2947,20 @@ ZR308(GrammarP sid_current_grammar)
 
 			/* BEGINNING OF ACTION: save-tuple */
 			{
-#line 377 "parser.act"
+#line 369 "parser.act"
 
 		sid_saved_pred_id = sid_current_pred_id;
 	
-#line 2957 "parser.c"
+#line 2955 "parser.c"
 			}
 			/* END OF ACTION: save-tuple */
 			/* BEGINNING OF ACTION: init-tuple */
 			{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI214));
 	
-#line 2966 "parser.c"
+#line 2964 "parser.c"
 			}
 			/* END OF ACTION: init-tuple */
 			ADVANCE_LEXER;
@@ -3016,7 +3015,7 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 						}
 						/* BEGINNING OF ACTION: x-prod-rule */
 						{
-#line 1282 "parser.act"
+#line 1267 "parser.act"
 
 		TypeTupleT *param  = NULL;
 		TypeTupleT *result = NULL;
@@ -3140,7 +3139,7 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 			types_destroy((&ZI217));
 		}
 	
-#line 3145 "parser.c"
+#line 3143 "parser.c"
 						}
 						/* END OF ACTION: x-prod-rule */
 						ZR247 (sid_current_grammar);
@@ -3154,16 +3153,16 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 					{
 						/* BEGINNING OF ACTION: current-tuple */
 						{
-#line 373 "parser.act"
+#line 365 "parser.act"
 
 		sid_current_pred_id = false;
 	
-#line 3163 "parser.c"
+#line 3161 "parser.c"
 						}
 						/* END OF ACTION: current-tuple */
 						/* BEGINNING OF ACTION: x-prod-rule-or-identity */
 						{
-#line 1398 "parser.act"
+#line 1391 "parser.act"
 
 		EntryT     *name_entry = table_get_entry(grammar_table(sid_current_grammar), (&ZI163));
 		EntryT     *entry      = NULL;
@@ -3382,7 +3381,7 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 			types_destroy(&rhs);
 		}
 	
-#line 3387 "parser.c"
+#line 3385 "parser.c"
 						}
 						/* END OF ACTION: x-prod-rule-or-identity */
 						ADVANCE_LEXER;
@@ -3399,27 +3398,27 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 				{
 					/* BEGINNING OF ACTION: expected-tuple-or-terminator */
 					{
-#line 1738 "parser.act"
+#line 1728 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("tuple or ';'");
 		}
 	
-#line 3410 "parser.c"
+#line 3408 "parser.c"
 					}
 					/* END OF ACTION: expected-tuple-or-terminator */
 					/* BEGINNING OF ACTION: destroy-string */
 					{
-#line 1831 "parser.act"
+#line 1824 "parser.act"
 
 		nstring_destroy(&(ZI163));
 	
-#line 3419 "parser.c"
+#line 3417 "parser.c"
 					}
 					/* END OF ACTION: destroy-string */
 					/* BEGINNING OF ACTION: skip-to-end-of-item */
 					{
-#line 1973 "parser.act"
+#line 1966 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -3446,7 +3445,7 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 
 		sid_propagating_error = true;
 	
-#line 3451 "parser.c"
+#line 3449 "parser.c"
 					}
 					/* END OF ACTION: skip-to-end-of-item */
 				}
@@ -3466,7 +3465,7 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 			}
 			/* BEGINNING OF ACTION: x-identity */
 			{
-#line 1204 "parser.act"
+#line 1194 "parser.act"
 
 		if (sid_current_entry && sid_current_alt) {
 			EntryT *entry = table_add_rename(grammar_table(sid_current_grammar));
@@ -3539,7 +3538,7 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 			types_destroy((&ZI217));
 		}
 	
-#line 3544 "parser.c"
+#line 3542 "parser.c"
 			}
 			/* END OF ACTION: x-identity */
 			ZR247 (sid_current_grammar);
@@ -3555,21 +3554,21 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 
 			/* BEGINNING OF ACTION: current-tuple */
 			{
-#line 373 "parser.act"
+#line 365 "parser.act"
 
 		sid_current_pred_id = false;
 	
-#line 3564 "parser.c"
+#line 3562 "parser.c"
 			}
 			/* END OF ACTION: current-tuple */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: init-tuple */
 			{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI217));
 	
-#line 3574 "parser.c"
+#line 3572 "parser.c"
 			}
 			/* END OF ACTION: init-tuple */
 			/* BEGINNING OF INLINE: 225 */
@@ -3584,7 +3583,7 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 					}
 					/* BEGINNING OF ACTION: add-ref-name */
 					{
-#line 457 "parser.act"
+#line 445 "parser.act"
 
 		NStringT scope;
 		EntryT *non_local_entry;
@@ -3624,12 +3623,12 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 			types_add_name((&ZI217), grammar_table(sid_current_grammar), &(ZI163), true);
 		}
 	
-#line 3629 "parser.c"
+#line 3627 "parser.c"
 					}
 					/* END OF ACTION: add-ref-name */
 					/* BEGINNING OF ACTION: x-identity */
 					{
-#line 1204 "parser.act"
+#line 1194 "parser.act"
 
 		if (sid_current_entry && sid_current_alt) {
 			EntryT *entry = table_add_rename(grammar_table(sid_current_grammar));
@@ -3702,7 +3701,7 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 			types_destroy((&ZI217));
 		}
 	
-#line 3707 "parser.c"
+#line 3705 "parser.c"
 					}
 					/* END OF ACTION: x-identity */
 					ZR247 (sid_current_grammar);
@@ -3716,18 +3715,18 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 				{
 					/* BEGINNING OF ACTION: expected-identifier-or-basic */
 					{
-#line 1660 "parser.act"
+#line 1650 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier or terminal");
 		}
 	
-#line 3727 "parser.c"
+#line 3725 "parser.c"
 					}
 					/* END OF ACTION: expected-identifier-or-basic */
 					/* BEGINNING OF ACTION: skip-to-end-of-item */
 					{
-#line 1973 "parser.act"
+#line 1966 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -3754,7 +3753,7 @@ ZR219(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 
 		sid_propagating_error = true;
 	
-#line 3759 "parser.c"
+#line 3757 "parser.c"
 					}
 					/* END OF ACTION: skip-to-end-of-item */
 				}
@@ -3773,18 +3772,18 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-item-rhs */
 		{
-#line 1744 "parser.act"
+#line 1734 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("item right hand side");
 		}
 	
-#line 3784 "parser.c"
+#line 3782 "parser.c"
 		}
 		/* END OF ACTION: expected-item-rhs */
 		/* BEGINNING OF ACTION: skip-to-end-of-item */
 		{
-#line 1973 "parser.act"
+#line 1966 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -3811,7 +3810,7 @@ ZL1:;
 
 		sid_propagating_error = true;
 	
-#line 3816 "parser.c"
+#line 3814 "parser.c"
 		}
 		/* END OF ACTION: skip-to-end-of-item */
 	}
@@ -3827,16 +3826,16 @@ ZR309(GrammarP sid_current_grammar, NStringT *ZI163)
 
 			/* BEGINNING OF ACTION: init-tuple */
 			{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI214));
 	
-#line 3836 "parser.c"
+#line 3834 "parser.c"
 			}
 			/* END OF ACTION: init-tuple */
 			/* BEGINNING OF ACTION: add-name */
 			{
-#line 416 "parser.act"
+#line 404 "parser.act"
 
 		NStringT scope;
 		EntryT *non_local_entry;
@@ -3876,16 +3875,16 @@ ZR309(GrammarP sid_current_grammar, NStringT *ZI163)
 			types_add_name((&ZI214), grammar_table(sid_current_grammar), &(*ZI163), false);
 		}
 	
-#line 3881 "parser.c"
+#line 3879 "parser.c"
 			}
 			/* END OF ACTION: add-name */
 			/* BEGINNING OF ACTION: save-tuple */
 			{
-#line 377 "parser.act"
+#line 369 "parser.act"
 
 		sid_saved_pred_id = sid_current_pred_id;
 	
-#line 3890 "parser.c"
+#line 3888 "parser.c"
 			}
 			/* END OF ACTION: save-tuple */
 			ADVANCE_LEXER;
@@ -3900,11 +3899,11 @@ ZR309(GrammarP sid_current_grammar, NStringT *ZI163)
 		{
 			/* BEGINNING OF ACTION: save-tuple */
 			{
-#line 377 "parser.act"
+#line 369 "parser.act"
 
 		sid_saved_pred_id = sid_current_pred_id;
 	
-#line 3909 "parser.c"
+#line 3907 "parser.c"
 			}
 			/* END OF ACTION: save-tuple */
 			ZR310 (sid_current_grammar, ZI163);
@@ -3972,34 +3971,34 @@ ZR310(GrammarP sid_current_grammar, NStringT *ZI163)
 
 			/* BEGINNING OF ACTION: current-tuple */
 			{
-#line 373 "parser.act"
+#line 365 "parser.act"
 
 		sid_current_pred_id = false;
 	
-#line 3981 "parser.c"
+#line 3979 "parser.c"
 			}
 			/* END OF ACTION: current-tuple */
 			/* BEGINNING OF ACTION: init-tuple */
 			{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI214));
 	
-#line 3990 "parser.c"
+#line 3988 "parser.c"
 			}
 			/* END OF ACTION: init-tuple */
 			/* BEGINNING OF ACTION: init-tuple */
 			{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI217));
 	
-#line 3999 "parser.c"
+#line 3997 "parser.c"
 			}
 			/* END OF ACTION: init-tuple */
 			/* BEGINNING OF ACTION: x-prod-rule */
 			{
-#line 1282 "parser.act"
+#line 1267 "parser.act"
 
 		TypeTupleT *param  = NULL;
 		TypeTupleT *result = NULL;
@@ -4123,7 +4122,7 @@ ZR310(GrammarP sid_current_grammar, NStringT *ZI163)
 			types_destroy((&ZI217));
 		}
 	
-#line 4128 "parser.c"
+#line 4126 "parser.c"
 			}
 			/* END OF ACTION: x-prod-rule */
 			ADVANCE_LEXER;
@@ -4136,11 +4135,11 @@ ZR310(GrammarP sid_current_grammar, NStringT *ZI163)
 
 			/* BEGINNING OF ACTION: init-tuple */
 			{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI214));
 	
-#line 4145 "parser.c"
+#line 4143 "parser.c"
 			}
 			/* END OF ACTION: init-tuple */
 			ZR191 (sid_current_grammar, &ZI217);
@@ -4150,7 +4149,7 @@ ZR310(GrammarP sid_current_grammar, NStringT *ZI163)
 			}
 			/* BEGINNING OF ACTION: x-prod-rule */
 			{
-#line 1282 "parser.act"
+#line 1267 "parser.act"
 
 		TypeTupleT *param  = NULL;
 		TypeTupleT *result = NULL;
@@ -4274,7 +4273,7 @@ ZR310(GrammarP sid_current_grammar, NStringT *ZI163)
 			types_destroy((&ZI217));
 		}
 	
-#line 4279 "parser.c"
+#line 4277 "parser.c"
 			}
 			/* END OF ACTION: x-prod-rule */
 			ZR247 (sid_current_grammar);
@@ -4310,11 +4309,11 @@ ZL2_168:;
 		}
 		/* BEGINNING OF ACTION: skip-recover */
 		{
-#line 2095 "parser.act"
+#line 2087 "parser.act"
 
 		sid_propagating_error = false;
 	
-#line 4319 "parser.c"
+#line 4317 "parser.c"
 		}
 		/* END OF ACTION: skip-recover */
 		/* BEGINNING OF INLINE: 176 */
@@ -4354,7 +4353,7 @@ ZR215(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 			}
 			/* BEGINNING OF ACTION: x-prod-action */
 			{
-#line 1126 "parser.act"
+#line 1110 "parser.act"
 
 		if (sid_current_item) {
 			bool    errored = false;
@@ -4438,7 +4437,7 @@ ZR215(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 			types_destroy((&ZI217));
 		}
 	
-#line 4443 "parser.c"
+#line 4441 "parser.c"
 			}
 			/* END OF ACTION: x-prod-action */
 			ZR247 (sid_current_grammar);
@@ -4454,25 +4453,25 @@ ZR215(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 
 			/* BEGINNING OF ACTION: current-tuple */
 			{
-#line 373 "parser.act"
+#line 365 "parser.act"
 
 		sid_current_pred_id = false;
 	
-#line 4463 "parser.c"
+#line 4461 "parser.c"
 			}
 			/* END OF ACTION: current-tuple */
 			/* BEGINNING OF ACTION: init-tuple */
 			{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI217));
 	
-#line 4472 "parser.c"
+#line 4470 "parser.c"
 			}
 			/* END OF ACTION: init-tuple */
 			/* BEGINNING OF ACTION: x-prod-action */
 			{
-#line 1126 "parser.act"
+#line 1110 "parser.act"
 
 		if (sid_current_item) {
 			bool    errored = false;
@@ -4556,7 +4555,7 @@ ZR215(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 			types_destroy((&ZI217));
 		}
 	
-#line 4561 "parser.c"
+#line 4559 "parser.c"
 			}
 			/* END OF ACTION: x-prod-action */
 			ADVANCE_LEXER;
@@ -4572,18 +4571,18 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-tuple-or-terminator */
 		{
-#line 1738 "parser.act"
+#line 1728 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("tuple or ';'");
 		}
 	
-#line 4583 "parser.c"
+#line 4581 "parser.c"
 		}
 		/* END OF ACTION: expected-tuple-or-terminator */
 		/* BEGINNING OF ACTION: skip-to-end-of-item */
 		{
-#line 1973 "parser.act"
+#line 1966 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -4610,7 +4609,7 @@ ZL1:;
 
 		sid_propagating_error = true;
 	
-#line 4615 "parser.c"
+#line 4613 "parser.c"
 		}
 		/* END OF ACTION: skip-to-end-of-item */
 	}
@@ -4631,11 +4630,11 @@ ZR274(GrammarP sid_current_grammar)
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: use-global */
 					{
-#line 556 "parser.act"
+#line 548 "parser.act"
 
 		sid_current_scope = &sid_global_scope;
 	
-#line 4640 "parser.c"
+#line 4638 "parser.c"
 					}
 					/* END OF ACTION: use-global */
 				}
@@ -4644,11 +4643,11 @@ ZR274(GrammarP sid_current_grammar)
 				{
 					/* BEGINNING OF ACTION: use-local */
 					{
-#line 560 "parser.act"
+#line 552 "parser.act"
 
 		sid_current_scope = &sid_scope_stack;
 	
-#line 4653 "parser.c"
+#line 4651 "parser.c"
 					}
 					/* END OF ACTION: use-local */
 				}
@@ -4699,11 +4698,11 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 
 			/* BEGINNING OF EXTRACT: IDENTIFIER */
 			{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI141, lexer_string_value(sid_current_stream));
 	
-#line 4708 "parser.c"
+#line 4706 "parser.c"
 			}
 			/* END OF EXTRACT: IDENTIFIER */
 			ADVANCE_LEXER;
@@ -4723,13 +4722,13 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 				{
 					/* BEGINNING OF ACTION: expected-typemark */
 					{
-#line 1648 "parser.act"
+#line 1638 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("':'");
 		}
 	
-#line 4734 "parser.c"
+#line 4732 "parser.c"
 					}
 					/* END OF ACTION: expected-typemark */
 				}
@@ -4745,11 +4744,11 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 					case (LEXER_TOK_IDENTIFIER):
 						/* BEGINNING OF EXTRACT: IDENTIFIER */
 						{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI144, lexer_string_value(sid_current_stream));
 	
-#line 4754 "parser.c"
+#line 4752 "parser.c"
 						}
 						/* END OF EXTRACT: IDENTIFIER */
 						break;
@@ -4765,7 +4764,7 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 								ADVANCE_LEXER;
 								/* BEGINNING OF ACTION: tuple-ref-name */
 								{
-#line 388 "parser.act"
+#line 381 "parser.act"
 
 		if (!types_add_typed_name((ZI138), grammar_table(sid_current_grammar),
 			&(ZI141), (&ZI144), true)) {
@@ -4773,7 +4772,7 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 		}
 		nstring_destroy(&(ZI144));
 	
-#line 4778 "parser.c"
+#line 4776 "parser.c"
 								}
 								/* END OF ACTION: tuple-ref-name */
 							}
@@ -4782,7 +4781,7 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 							{
 								/* BEGINNING OF ACTION: tuple-name */
 								{
-#line 380 "parser.act"
+#line 373 "parser.act"
 
 		if (!types_add_typed_name((ZI138), grammar_table(sid_current_grammar),
 			&(ZI141), (&ZI144), false)) {
@@ -4790,7 +4789,7 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 		}
 		nstring_destroy(&(ZI144));
 	
-#line 4795 "parser.c"
+#line 4793 "parser.c"
 								}
 								/* END OF ACTION: tuple-name */
 							}
@@ -4804,27 +4803,27 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 				{
 					/* BEGINNING OF ACTION: expected-identifier */
 					{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 4815 "parser.c"
+#line 4813 "parser.c"
 					}
 					/* END OF ACTION: expected-identifier */
 					/* BEGINNING OF ACTION: destroy-string */
 					{
-#line 1831 "parser.act"
+#line 1824 "parser.act"
 
 		nstring_destroy(&(ZI141));
 	
-#line 4824 "parser.c"
+#line 4822 "parser.c"
 					}
 					/* END OF ACTION: destroy-string */
 					/* BEGINNING OF ACTION: skip-to-end-of-tuple-defn */
 					{
-#line 1837 "parser.act"
+#line 1829 "parser.act"
 
 		if (sid_finished_terminals) {
 			while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
@@ -4872,7 +4871,7 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 
 		sid_propagating_error = true;
 	
-#line 4877 "parser.c"
+#line 4875 "parser.c"
 					}
 					/* END OF ACTION: skip-to-end-of-tuple-defn */
 				}
@@ -4893,11 +4892,11 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 					case (LEXER_TOK_IDENTIFIER):
 						/* BEGINNING OF EXTRACT: IDENTIFIER */
 						{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI144, lexer_string_value(sid_current_stream));
 	
-#line 4902 "parser.c"
+#line 4900 "parser.c"
 						}
 						/* END OF EXTRACT: IDENTIFIER */
 						break;
@@ -4913,14 +4912,14 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 								ADVANCE_LEXER;
 								/* BEGINNING OF ACTION: tuple-ref-type */
 								{
-#line 404 "parser.act"
+#line 397 "parser.act"
 
 		if (!types_add_type((ZI138), grammar_table(sid_current_grammar), (&ZI144), true)) {
 			err_unknown("type", (&ZI144));
 		}
 		nstring_destroy(&(ZI144));
 	
-#line 4925 "parser.c"
+#line 4923 "parser.c"
 								}
 								/* END OF ACTION: tuple-ref-type */
 							}
@@ -4929,7 +4928,7 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 							{
 								/* BEGINNING OF ACTION: tuple-type */
 								{
-#line 396 "parser.act"
+#line 389 "parser.act"
 
 		if (!types_add_type((ZI138), grammar_table(sid_current_grammar), (&ZI144),
 			false)) {
@@ -4937,7 +4936,7 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 		}
 		nstring_destroy(&(ZI144));
 	
-#line 4942 "parser.c"
+#line 4940 "parser.c"
 								}
 								/* END OF ACTION: tuple-type */
 							}
@@ -4951,18 +4950,18 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 				{
 					/* BEGINNING OF ACTION: expected-identifier */
 					{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 4962 "parser.c"
+#line 4960 "parser.c"
 					}
 					/* END OF ACTION: expected-identifier */
 					/* BEGINNING OF ACTION: skip-to-end-of-tuple-defn */
 					{
-#line 1837 "parser.act"
+#line 1829 "parser.act"
 
 		if (sid_finished_terminals) {
 			while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
@@ -5010,7 +5009,7 @@ ZR139(GrammarP sid_current_grammar, TypeTupleT *ZI138)
 
 		sid_propagating_error = true;
 	
-#line 5015 "parser.c"
+#line 5013 "parser.c"
 					}
 					/* END OF ACTION: skip-to-end-of-tuple-defn */
 				}
@@ -5029,18 +5028,18 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-tuple-defn */
 		{
-#line 1666 "parser.act"
+#line 1656 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier or ':'");
 		}
 	
-#line 5040 "parser.c"
+#line 5038 "parser.c"
 		}
 		/* END OF ACTION: expected-tuple-defn */
 		/* BEGINNING OF ACTION: skip-to-end-of-tuple-defn */
 		{
-#line 1837 "parser.act"
+#line 1829 "parser.act"
 
 		if (sid_finished_terminals) {
 			while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
@@ -5088,7 +5087,7 @@ ZL1:;
 
 		sid_propagating_error = true;
 	
-#line 5093 "parser.c"
+#line 5091 "parser.c"
 		}
 		/* END OF ACTION: skip-to-end-of-tuple-defn */
 	}
@@ -5112,11 +5111,11 @@ ZL2_280:;
 			{
 				/* BEGINNING OF ACTION: is-terminator */
 				{
-#line 2110 "parser.act"
+#line 2103 "parser.act"
 
 		(ZI0) = (CURRENT_TERMINAL == (LEXER_TOK_TERMINATOR));
 	
-#line 5121 "parser.c"
+#line 5119 "parser.c"
 				}
 				/* END OF ACTION: is-terminator */
 				if (!ZI0)
@@ -5142,18 +5141,18 @@ ZL2_280:;
 			{
 				/* BEGINNING OF ACTION: expected-separator */
 				{
-#line 1678 "parser.act"
+#line 1668 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("','");
 		}
 	
-#line 5153 "parser.c"
+#line 5151 "parser.c"
 				}
 				/* END OF ACTION: expected-separator */
 				/* BEGINNING OF ACTION: skip-to-end-of-entry-list */
 				{
-#line 2073 "parser.act"
+#line 2066 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -5174,16 +5173,16 @@ ZL2_280:;
 
 		sid_propagating_error = true;
 	
-#line 5179 "parser.c"
+#line 5177 "parser.c"
 				}
 				/* END OF ACTION: skip-to-end-of-entry-list */
 				/* BEGINNING OF ACTION: skip-recover */
 				{
-#line 2095 "parser.act"
+#line 2087 "parser.act"
 
 		sid_propagating_error = false;
 	
-#line 5188 "parser.c"
+#line 5186 "parser.c"
 				}
 				/* END OF ACTION: skip-recover */
 				/* BEGINNING OF INLINE: 284 */
@@ -5191,11 +5190,11 @@ ZL2_280:;
 					{
 						/* BEGINNING OF ACTION: is-not-separator */
 						{
-#line 2114 "parser.act"
+#line 2107 "parser.act"
 
 		(ZI0) = (CURRENT_TERMINAL != (LEXER_TOK_SEPARATOR));
 	
-#line 5200 "parser.c"
+#line 5198 "parser.c"
 						}
 						/* END OF ACTION: is-not-separator */
 						if (!ZI0)
@@ -5243,13 +5242,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-open-tuple */
 		{
-#line 1684 "parser.act"
+#line 1674 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("'('");
 		}
 	
-#line 5254 "parser.c"
+#line 5252 "parser.c"
 		}
 		/* END OF ACTION: expected-open-tuple */
 	}
@@ -5275,13 +5274,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-close-tuple */
 		{
-#line 1690 "parser.act"
+#line 1680 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("')'");
 		}
 	
-#line 5286 "parser.c"
+#line 5284 "parser.c"
 		}
 		/* END OF ACTION: expected-close-tuple */
 	}
@@ -5304,11 +5303,11 @@ ZR136(GrammarP sid_current_grammar, TypeTupleT *ZO134, TypeTupleT *ZO135)
 			}
 			/* BEGINNING OF ACTION: save-tuple */
 			{
-#line 377 "parser.act"
+#line 369 "parser.act"
 
 		sid_saved_pred_id = sid_current_pred_id;
 	
-#line 5313 "parser.c"
+#line 5311 "parser.c"
 			}
 			/* END OF ACTION: save-tuple */
 			ZR157 (sid_current_grammar);
@@ -5323,20 +5322,20 @@ ZR136(GrammarP sid_current_grammar, TypeTupleT *ZO134, TypeTupleT *ZO135)
 		{
 			/* BEGINNING OF ACTION: init-tuple */
 			{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI134));
 	
-#line 5332 "parser.c"
+#line 5330 "parser.c"
 			}
 			/* END OF ACTION: init-tuple */
 			/* BEGINNING OF ACTION: init-tuple */
 			{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI135));
 	
-#line 5341 "parser.c"
+#line 5339 "parser.c"
 			}
 			/* END OF ACTION: init-tuple */
 		}
@@ -5351,7 +5350,7 @@ ZL1:;
 ZL0:;
 	/* BEGINNING OF RESULT ASSIGNMENT: TypeTupleT */
 	{
-#line 232 "parser.act"
+#line 225 "parser.act"
 
 		ZO134->head = ZI134.head;
 
@@ -5360,12 +5359,12 @@ ZL0:;
 		} else {
 			ZO134->tail= ZI134.tail ;
 		}
-	#line 5365 "parser.c"
+	#line 5363 "parser.c"
 	}
 	/* END OF RESULT ASSIGNMENT: TypeTupleT */
 	/* BEGINNING OF RESULT ASSIGNMENT: TypeTupleT */
 	{
-#line 232 "parser.act"
+#line 225 "parser.act"
 
 		ZO135->head = ZI135.head;
 
@@ -5374,7 +5373,7 @@ ZL0:;
 		} else {
 			ZO135->tail= ZI135.tail ;
 		}
-	#line 5379 "parser.c"
+	#line 5377 "parser.c"
 	}
 	/* END OF RESULT ASSIGNMENT: TypeTupleT */
 }
@@ -5396,11 +5395,11 @@ ZR228(GrammarP sid_current_grammar)
 					case (LEXER_TOK_IDENTIFIER):
 						/* BEGINNING OF EXTRACT: IDENTIFIER */
 						{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI163, lexer_string_value(sid_current_stream));
 	
-#line 5405 "parser.c"
+#line 5403 "parser.c"
 						}
 						/* END OF EXTRACT: IDENTIFIER */
 						break;
@@ -5410,25 +5409,25 @@ ZR228(GrammarP sid_current_grammar)
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: current-tuple */
 					{
-#line 373 "parser.act"
+#line 365 "parser.act"
 
 		sid_current_pred_id = false;
 	
-#line 5419 "parser.c"
+#line 5417 "parser.c"
 					}
 					/* END OF ACTION: current-tuple */
 					/* BEGINNING OF ACTION: init-tuple */
 					{
-#line 368 "parser.act"
+#line 361 "parser.act"
 
 		types_init(&(ZI214));
 	
-#line 5428 "parser.c"
+#line 5426 "parser.c"
 					}
 					/* END OF ACTION: init-tuple */
 					/* BEGINNING OF ACTION: add-var */
 					{
-#line 497 "parser.act"
+#line 485 "parser.act"
 
 		NStringT scope;
 		EntryT *non_local_entry;
@@ -5470,16 +5469,16 @@ ZR228(GrammarP sid_current_grammar)
 			types_add_name((&ZI214), grammar_table(sid_current_grammar), &(ZI163), false);
 		}
 	
-#line 5475 "parser.c"
+#line 5473 "parser.c"
 					}
 					/* END OF ACTION: add-var */
 					/* BEGINNING OF ACTION: save-tuple */
 					{
-#line 377 "parser.act"
+#line 369 "parser.act"
 
 		sid_saved_pred_id = sid_current_pred_id;
 	
-#line 5484 "parser.c"
+#line 5482 "parser.c"
 					}
 					/* END OF ACTION: save-tuple */
 					ZR234 (sid_current_grammar);
@@ -5494,13 +5493,13 @@ ZR228(GrammarP sid_current_grammar)
 				{
 					/* BEGINNING OF ACTION: expected-identifier */
 					{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 5505 "parser.c"
+#line 5503 "parser.c"
 					}
 					/* END OF ACTION: expected-identifier */
 				}
@@ -5523,11 +5522,11 @@ ZR228(GrammarP sid_current_grammar)
 				{
 					/* BEGINNING OF ACTION: current-tuple */
 					{
-#line 373 "parser.act"
+#line 365 "parser.act"
 
 		sid_current_pred_id = false;
 	
-#line 5532 "parser.c"
+#line 5530 "parser.c"
 					}
 					/* END OF ACTION: current-tuple */
 					ZR309 (sid_current_grammar, &ZI163);
@@ -5541,27 +5540,27 @@ ZR228(GrammarP sid_current_grammar)
 				{
 					/* BEGINNING OF ACTION: expected-tuple-or-define-or-terminator */
 					{
-#line 1756 "parser.act"
+#line 1746 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("tuple, '=' or ';'");
 		}
 	
-#line 5552 "parser.c"
+#line 5550 "parser.c"
 					}
 					/* END OF ACTION: expected-tuple-or-define-or-terminator */
 					/* BEGINNING OF ACTION: destroy-string */
 					{
-#line 1831 "parser.act"
+#line 1824 "parser.act"
 
 		nstring_destroy(&(ZI163));
 	
-#line 5561 "parser.c"
+#line 5559 "parser.c"
 					}
 					/* END OF ACTION: destroy-string */
 					/* BEGINNING OF ACTION: skip-to-end-of-item */
 					{
-#line 1973 "parser.act"
+#line 1966 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -5588,7 +5587,7 @@ ZR228(GrammarP sid_current_grammar)
 
 		sid_propagating_error = true;
 	
-#line 5593 "parser.c"
+#line 5591 "parser.c"
 					}
 					/* END OF ACTION: skip-to-end-of-item */
 				}
@@ -5608,11 +5607,11 @@ ZR228(GrammarP sid_current_grammar)
 			}
 			/* BEGINNING OF ACTION: save-tuple */
 			{
-#line 377 "parser.act"
+#line 369 "parser.act"
 
 		sid_saved_pred_id = sid_current_pred_id;
 	
-#line 5617 "parser.c"
+#line 5615 "parser.c"
 			}
 			/* END OF ACTION: save-tuple */
 			ZR234 (sid_current_grammar);
@@ -5627,11 +5626,11 @@ ZR228(GrammarP sid_current_grammar)
 		{
 			/* BEGINNING OF ACTION: current-tuple */
 			{
-#line 373 "parser.act"
+#line 365 "parser.act"
 
 		sid_current_pred_id = false;
 	
-#line 5636 "parser.c"
+#line 5634 "parser.c"
 			}
 			/* END OF ACTION: current-tuple */
 			ZR308 (sid_current_grammar);
@@ -5674,7 +5673,7 @@ ZR170(GrammarP sid_current_grammar)
 					}
 					/* BEGINNING OF ACTION: i-terminal */
 					{
-#line 292 "parser.act"
+#line 285 "parser.act"
 
 		(ZI172) = table_add_basic(grammar_table(sid_current_grammar), &(ZI163),
 			sid_current_grammar, true);
@@ -5683,7 +5682,7 @@ ZR170(GrammarP sid_current_grammar)
 			nstring_destroy(&(ZI163));
 		}
 	
-#line 5688 "parser.c"
+#line 5686 "parser.c"
 					}
 					/* END OF ACTION: i-terminal */
 					ZR136 (sid_current_grammar, &ZI134, &ZI135);
@@ -5693,7 +5692,7 @@ ZR170(GrammarP sid_current_grammar)
 					}
 					/* BEGINNING OF ACTION: x-terminal */
 					{
-#line 301 "parser.act"
+#line 294 "parser.act"
 
 		if ((ZI172)) {
 			KeyT *key = entry_key((ZI172));
@@ -5735,7 +5734,7 @@ ZR170(GrammarP sid_current_grammar)
 		}
 		types_destroy((&ZI134));
 	
-#line 5740 "parser.c"
+#line 5738 "parser.c"
 					}
 					/* END OF ACTION: x-terminal */
 					ZR247 (sid_current_grammar);
@@ -5749,18 +5748,18 @@ ZR170(GrammarP sid_current_grammar)
 				{
 					/* BEGINNING OF ACTION: expected-identifier */
 					{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 5760 "parser.c"
+#line 5758 "parser.c"
 					}
 					/* END OF ACTION: expected-identifier */
 					/* BEGINNING OF ACTION: skip-to-end-of-terminal-decn */
 					{
-#line 1884 "parser.act"
+#line 1877 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -5782,7 +5781,7 @@ ZR170(GrammarP sid_current_grammar)
 
 		sid_propagating_error = true;
 	
-#line 5787 "parser.c"
+#line 5785 "parser.c"
 					}
 					/* END OF ACTION: skip-to-end-of-terminal-decn */
 				}
@@ -5805,7 +5804,7 @@ ZR170(GrammarP sid_current_grammar)
 			}
 			/* BEGINNING OF ACTION: terminal */
 			{
-#line 283 "parser.act"
+#line 276 "parser.act"
 
 		(ZI172) = table_add_basic(grammar_table(sid_current_grammar), &(ZI163),
 			sid_current_grammar, false);
@@ -5814,7 +5813,7 @@ ZR170(GrammarP sid_current_grammar)
 			nstring_destroy(&(ZI163));
 		}
 	
-#line 5819 "parser.c"
+#line 5817 "parser.c"
 			}
 			/* END OF ACTION: terminal */
 			ZR136 (sid_current_grammar, &ZI134, &ZI135);
@@ -5824,7 +5823,7 @@ ZR170(GrammarP sid_current_grammar)
 			}
 			/* BEGINNING OF ACTION: x-terminal */
 			{
-#line 301 "parser.act"
+#line 294 "parser.act"
 
 		if ((ZI172)) {
 			KeyT *key = entry_key((ZI172));
@@ -5866,7 +5865,7 @@ ZR170(GrammarP sid_current_grammar)
 		}
 		types_destroy((&ZI134));
 	
-#line 5871 "parser.c"
+#line 5869 "parser.c"
 			}
 			/* END OF ACTION: x-terminal */
 			ZR247 (sid_current_grammar);
@@ -5886,18 +5885,18 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-terminal-decn */
 		{
-#line 1672 "parser.act"
+#line 1662 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier or '!'");
 		}
 	
-#line 5897 "parser.c"
+#line 5895 "parser.c"
 		}
 		/* END OF ACTION: expected-terminal-decn */
 		/* BEGINNING OF ACTION: skip-to-end-of-terminal-decn */
 		{
-#line 1884 "parser.act"
+#line 1877 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -5919,7 +5918,7 @@ ZL1:;
 
 		sid_propagating_error = true;
 	
-#line 5924 "parser.c"
+#line 5922 "parser.c"
 		}
 		/* END OF ACTION: skip-to-end-of-terminal-decn */
 	}
@@ -5947,11 +5946,11 @@ ZR203(GrammarP sid_current_grammar)
 					case (LEXER_TOK_IDENTIFIER):
 						/* BEGINNING OF EXTRACT: IDENTIFIER */
 						{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI163, lexer_string_value(sid_current_stream));
 	
-#line 5956 "parser.c"
+#line 5954 "parser.c"
 						}
 						/* END OF EXTRACT: IDENTIFIER */
 						break;
@@ -5961,7 +5960,7 @@ ZR203(GrammarP sid_current_grammar)
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: action */
 					{
-#line 563 "parser.act"
+#line 556 "parser.act"
 
 		(ZI172) = scope_stack_add_action(sid_current_scope,
 			grammar_table(sid_current_grammar), &(ZI163), sid_enclosing_rule,
@@ -5972,7 +5971,7 @@ ZR203(GrammarP sid_current_grammar)
 			nstring_destroy(&(ZI163));
 		}
 	
-#line 5977 "parser.c"
+#line 5975 "parser.c"
 					}
 					/* END OF ACTION: action */
 					ZR238 (sid_current_grammar);
@@ -5983,7 +5982,7 @@ ZR203(GrammarP sid_current_grammar)
 					}
 					/* BEGINNING OF ACTION: x-action */
 					{
-#line 585 "parser.act"
+#line 578 "parser.act"
 
 		if ((ZI172)) {
 			KeyT       *key     = entry_key(sid_current_entry);
@@ -6055,7 +6054,7 @@ ZR203(GrammarP sid_current_grammar)
 			types_destroy((&ZI135));
 		}
 	
-#line 6060 "parser.c"
+#line 6058 "parser.c"
 					}
 					/* END OF ACTION: x-action */
 					ZR247 (sid_current_grammar);
@@ -6087,11 +6086,11 @@ ZR203(GrammarP sid_current_grammar)
 							case (LEXER_TOK_IDENTIFIER):
 								/* BEGINNING OF EXTRACT: IDENTIFIER */
 								{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI163, lexer_string_value(sid_current_stream));
 	
-#line 6096 "parser.c"
+#line 6094 "parser.c"
 								}
 								/* END OF EXTRACT: IDENTIFIER */
 								break;
@@ -6101,7 +6100,7 @@ ZR203(GrammarP sid_current_grammar)
 							ADVANCE_LEXER;
 							/* BEGINNING OF ACTION: i-action */
 							{
-#line 574 "parser.act"
+#line 567 "parser.act"
 
 		(ZI172) = scope_stack_add_action(sid_current_scope,
 			grammar_table(sid_current_grammar), &(ZI163), sid_enclosing_rule,
@@ -6112,7 +6111,7 @@ ZR203(GrammarP sid_current_grammar)
 			nstring_destroy(&(ZI163));
 		}
 	
-#line 6117 "parser.c"
+#line 6115 "parser.c"
 							}
 							/* END OF ACTION: i-action */
 							ZR238 (sid_current_grammar);
@@ -6123,7 +6122,7 @@ ZR203(GrammarP sid_current_grammar)
 							}
 							/* BEGINNING OF ACTION: x-action */
 							{
-#line 585 "parser.act"
+#line 578 "parser.act"
 
 		if ((ZI172)) {
 			KeyT       *key     = entry_key(sid_current_entry);
@@ -6195,7 +6194,7 @@ ZR203(GrammarP sid_current_grammar)
 			types_destroy((&ZI135));
 		}
 	
-#line 6200 "parser.c"
+#line 6198 "parser.c"
 							}
 							/* END OF ACTION: x-action */
 							ZR247 (sid_current_grammar);
@@ -6209,18 +6208,18 @@ ZR203(GrammarP sid_current_grammar)
 						{
 							/* BEGINNING OF ACTION: expected-identifier */
 							{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 6220 "parser.c"
+#line 6218 "parser.c"
 							}
 							/* END OF ACTION: expected-identifier */
 							/* BEGINNING OF ACTION: skip-to-end-of-action-decn */
 							{
-#line 1950 "parser.act"
+#line 1943 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -6243,7 +6242,7 @@ ZR203(GrammarP sid_current_grammar)
 
 		sid_propagating_error = true;
 	
-#line 6248 "parser.c"
+#line 6246 "parser.c"
 							}
 							/* END OF ACTION: skip-to-end-of-action-decn */
 						}
@@ -6260,18 +6259,18 @@ ZR203(GrammarP sid_current_grammar)
 			{
 				/* BEGINNING OF ACTION: expected-identifier */
 				{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 6271 "parser.c"
+#line 6269 "parser.c"
 				}
 				/* END OF ACTION: expected-identifier */
 				/* BEGINNING OF ACTION: skip-to-end-of-action-decn */
 				{
-#line 1950 "parser.act"
+#line 1943 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -6294,7 +6293,7 @@ ZR203(GrammarP sid_current_grammar)
 
 		sid_propagating_error = true;
 	
-#line 6299 "parser.c"
+#line 6297 "parser.c"
 				}
 				/* END OF ACTION: skip-to-end-of-action-decn */
 			}
@@ -6324,13 +6323,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-define */
 		{
-#line 1750 "parser.act"
+#line 1740 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("'='");
 		}
 	
-#line 6335 "parser.c"
+#line 6333 "parser.c"
 		}
 		/* END OF ACTION: expected-define */
 	}
@@ -6370,18 +6369,18 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-item */
 		{
-#line 1774 "parser.act"
+#line 1764 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("item");
 		}
 	
-#line 6381 "parser.c"
+#line 6379 "parser.c"
 		}
 		/* END OF ACTION: expected-item */
 		/* BEGINNING OF ACTION: skip-to-end-of-item */
 		{
-#line 1973 "parser.act"
+#line 1966 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -6408,16 +6407,16 @@ ZL1:;
 
 		sid_propagating_error = true;
 	
-#line 6413 "parser.c"
+#line 6411 "parser.c"
 		}
 		/* END OF ACTION: skip-to-end-of-item */
 		/* BEGINNING OF ACTION: skip-recover */
 		{
-#line 2095 "parser.act"
+#line 2087 "parser.act"
 
 		sid_propagating_error = false;
 	
-#line 6422 "parser.c"
+#line 6420 "parser.c"
 		}
 		/* END OF ACTION: skip-recover */
 	}
@@ -6436,11 +6435,11 @@ ZR282(GrammarP sid_current_grammar)
 		case (LEXER_TOK_IDENTIFIER):
 			/* BEGINNING OF EXTRACT: IDENTIFIER */
 			{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI163, lexer_string_value(sid_current_stream));
 	
-#line 6445 "parser.c"
+#line 6443 "parser.c"
 			}
 			/* END OF EXTRACT: IDENTIFIER */
 			break;
@@ -6450,7 +6449,7 @@ ZR282(GrammarP sid_current_grammar)
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-entry */
 		{
-#line 1619 "parser.act"
+#line 1610 "parser.act"
 
 		EntryT *entry;
 
@@ -6469,7 +6468,7 @@ ZR282(GrammarP sid_current_grammar)
 		}
 		nstring_destroy(&(ZI163));
 	
-#line 6474 "parser.c"
+#line 6472 "parser.c"
 		}
 		/* END OF ACTION: add-entry */
 	}
@@ -6478,13 +6477,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-identifier */
 		{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 6489 "parser.c"
+#line 6487 "parser.c"
 		}
 		/* END OF ACTION: expected-identifier */
 	}
@@ -6503,11 +6502,11 @@ ZR237(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 		case (LEXER_TOK_IDENTIFIER):
 			/* BEGINNING OF EXTRACT: IDENTIFIER */
 			{
-#line 244 "parser.act"
+#line 237 "parser.act"
 
 		nstring_assign(&ZI163, lexer_string_value(sid_current_stream));
 	
-#line 6512 "parser.c"
+#line 6510 "parser.c"
 			}
 			/* END OF EXTRACT: IDENTIFIER */
 			break;
@@ -6517,7 +6516,7 @@ ZR237(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: prod-action */
 		{
-#line 1101 "parser.act"
+#line 1090 "parser.act"
 
 		if (sid_current_entry && sid_current_alt) {
 			EntryT *entry;
@@ -6537,7 +6536,7 @@ ZR237(GrammarP sid_current_grammar, TypeTupleT *ZI214)
 		}
 		nstring_destroy(&(ZI163));
 	
-#line 6542 "parser.c"
+#line 6540 "parser.c"
 		}
 		/* END OF ACTION: prod-action */
 		ZR238 (sid_current_grammar);
@@ -6552,18 +6551,18 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-identifier */
 		{
-#line 1654 "parser.act"
+#line 1644 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("identifier");
 		}
 	
-#line 6563 "parser.c"
+#line 6561 "parser.c"
 		}
 		/* END OF ACTION: expected-identifier */
 		/* BEGINNING OF ACTION: skip-to-end-of-item */
 		{
-#line 1973 "parser.act"
+#line 1966 "parser.act"
 
 		while (CURRENT_TERMINAL != (LEXER_TOK_EOF)
 			&& CURRENT_TERMINAL != (LEXER_TOK_TERMINATOR)
@@ -6590,7 +6589,7 @@ ZL1:;
 
 		sid_propagating_error = true;
 	
-#line 6595 "parser.c"
+#line 6593 "parser.c"
 		}
 		/* END OF ACTION: skip-to-end-of-item */
 	}
@@ -6616,13 +6615,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-end-action */
 		{
-#line 1726 "parser.act"
+#line 1716 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("'>'");
 		}
 	
-#line 6627 "parser.c"
+#line 6625 "parser.c"
 		}
 		/* END OF ACTION: expected-end-action */
 	}
@@ -6646,13 +6645,13 @@ ZL2_184:;
 			{
 				/* BEGINNING OF ACTION: is-close-tuple-or-skipped-or-eof */
 				{
-#line 2104 "parser.act"
+#line 2097 "parser.act"
 
 		(ZI0) = (CURRENT_TERMINAL == (LEXER_TOK_CLOSE_HTUPLE)
 			|| CURRENT_TERMINAL == (LEXER_TOK_EOF)
 			|| sid_propagating_error);
 	
-#line 6657 "parser.c"
+#line 6655 "parser.c"
 				}
 				/* END OF ACTION: is-close-tuple-or-skipped-or-eof */
 				if (!ZI0)
@@ -6678,13 +6677,13 @@ ZL2_184:;
 			{
 				/* BEGINNING OF ACTION: expected-separator */
 				{
-#line 1678 "parser.act"
+#line 1668 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("','");
 		}
 	
-#line 6689 "parser.c"
+#line 6687 "parser.c"
 				}
 				/* END OF ACTION: expected-separator */
 				/* BEGINNING OF INLINE: sid-parse-grammar::production-defn-list::lhs-name-tuple::lhs-name-list-1 */
@@ -6722,13 +6721,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-end-rule */
 		{
-#line 1768 "parser.act"
+#line 1758 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("'}'");
 		}
 	
-#line 6733 "parser.c"
+#line 6731 "parser.c"
 		}
 		/* END OF ACTION: expected-end-rule */
 	}
@@ -6754,13 +6753,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: expected-terminator */
 		{
-#line 1702 "parser.act"
+#line 1692 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("';'");
 		}
 	
-#line 6765 "parser.c"
+#line 6763 "parser.c"
 		}
 		/* END OF ACTION: expected-terminator */
 	}
@@ -6784,13 +6783,13 @@ ZL2_196:;
 			{
 				/* BEGINNING OF ACTION: is-close-tuple-or-skipped-or-eof */
 				{
-#line 2104 "parser.act"
+#line 2097 "parser.act"
 
 		(ZI0) = (CURRENT_TERMINAL == (LEXER_TOK_CLOSE_HTUPLE)
 			|| CURRENT_TERMINAL == (LEXER_TOK_EOF)
 			|| sid_propagating_error);
 	
-#line 6795 "parser.c"
+#line 6793 "parser.c"
 				}
 				/* END OF ACTION: is-close-tuple-or-skipped-or-eof */
 				if (!ZI0)
@@ -6816,13 +6815,13 @@ ZL2_196:;
 			{
 				/* BEGINNING OF ACTION: expected-separator */
 				{
-#line 1678 "parser.act"
+#line 1668 "parser.act"
 
 		if (!sid_propagating_error) {
 			err_expected("','");
 		}
 	
-#line 6827 "parser.c"
+#line 6825 "parser.c"
 				}
 				/* END OF ACTION: expected-separator */
 				/* BEGINNING OF INLINE: sid-parse-grammar::production-defn-list::rhs-name-tuple::rhs-name-list-1 */
@@ -6842,9 +6841,9 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 2119 "parser.act"
+#line 2111 "parser.act"
 
 
-#line 6850 "parser.c"
+#line 6848 "parser.c"
 
 /* END OF FILE */

--- a/sid/src/parser.h
+++ b/sid/src/parser.h
@@ -9,8 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 187 "parser.act"
-
+#line 160 "parser.act"
 
 
 	/*
@@ -30,18 +29,18 @@
 	#include "grammar.h"
 	#include "lexer.h"
 
-	LexerStreamT *  sid_current_stream;
+	extern LexerStreamT *  sid_current_stream;
 
-#line 37 "parser.h"
+#line 35 "parser.h"
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
 extern void sid_parse_grammar(GrammarP);
 /* BEGINNING OF TRAILER */
 
-#line 2121 "parser.act"
+#line 2113 "parser.act"
 
 
-#line 47 "parser.h"
+#line 45 "parser.h"
 
 /* END OF FILE */


### PR DESCRIPTION
With GCC 10 / -fno-common, it is important to provide only a single definition of all objects, even objects that do not have any initializer. This commit adds extern to the declarations in headers.