### PR TITLE
Fail gracefully if sid needs to be run but ${SID} isn't a valid executable

### DIFF
--- a/shared/mk/tendra.base.mk
+++ b/shared/mk/tendra.base.mk
@@ -11,7 +11,7 @@ _TENDRA_BASE_MK_=1
 .MAIN: all
 
 # Ensure existence of basic targets.
-.for target in all clean install regen regen-clean test
+.for target in all clean install regen regen-clean test touch-generated-sid
 ${target}:: .PHONY
 .endfor
 
@@ -57,6 +57,7 @@ COPY?=		cp
 ECHO?=		echo
 ECHODIR?=	echo
 EXIT?=		exit
+FALSE?=		false
 FIND?=		find
 INSTALL?=	install
 LEXI?=		lexi
@@ -74,6 +75,7 @@ SHELL=		/bin/sh
 TEST?=		test
 TLD?=		tld
 TNC?=		tnc
+TOUCH?=		touch
 TPL?=		tpl
 TR?=		tr
 TSPEC?=		tspec

--- a/shared/mk/tendra.partial.mk
+++ b/shared/mk/tendra.partial.mk
@@ -51,6 +51,9 @@ clean::
 	    OBJ_SDIR=${OBJ_SDIR}/_partial/${part} \
 		clean
 
+touch-generated-sid::
+	@cd ${BASE_DIR}/${part} && ${MAKE} touch-generated-sid
+
 .endfor
 
 

--- a/shared/mk/tendra.sid.mk
+++ b/shared/mk/tendra.sid.mk
@@ -25,14 +25,35 @@ SIDSPLIT?=	@
 .endif
 
 
+# If sid is not available, and anything needs to be rebuilt, give the user
+# some hints about how to handle this and fail as gracefully as the
+# conditions permit.
+_SIDCHECK != command -v ${SID}
+.if !empty(_SIDCHECK)
 # TODO: really sid ought to delete its own output on error.
 .for src in ${SYNTAX}
 ${src:R}${SIDSPLIT}.c ${src:R}.h: ${src} ${ACTIONS:M${src:R}.act}
 	@${ECHO} "==> Translating ${WRKDIR}/${src}"
 	${SID} ${SIDOPTS} ${.ALLSRC} ${src:R}${SIDSPLIT}.c ${src:R}.h \
 		|| ( ${RMFILE} ${src:R}${SIDSPLIT:S/@/*/}.c ${src:R}.h; ${EXIT} 1 )
+touch-generated-sid::
+	${TOUCH} ${src:R}${SIDSPLIT}.c ${src:R}.h
 .endfor
-
+.else
+.for src in ${SYNTAX}
+${src:R}${SIDSPLIT}.c ${src:R}.h: ${src} ${ACTIONS:M${src:R}.act}
+	@${ECHO}
+	@${ECHO} "Need to run sid, and SID does not appear to point at a working executable!"
+	@${ECHO} "To use the in-tree built version of sid, run make with SID"
+	@${ECHO} "pointing at the in-tree executable."
+	@${ECHO} "To use the in-repository versions of generated files, run"
+	@${ECHO} "    make touch-generated-sid"
+	@${ECHO}
+	@${FALSE}
+touch-generated-sid::
+	${TOUCH} ${src:R}${SIDSPLIT}.c ${src:R}.h
+.endfor
+.endif
 
 
 #

--- a/shared/mk/tendra.subdir.mk
+++ b/shared/mk/tendra.subdir.mk
@@ -37,7 +37,7 @@ _TENDRA_SUBDIR_MK_=1
 .PHONY: ${SUBDIR}
 
 # Proceed to subdirs.
-. for target in all clean install regen regen-clean test
+. for target in all clean install regen regen-clean test touch-generated-sid
 ${target}::
 .  for entry in ${SUBDIR}
 	@cd ${.CURDIR}/${entry}; ${MAKE} ${.TARGET}


### PR DESCRIPTION
Add a check for whether `${SID}` references something we can actually execute.  If not, instead of generating rules that try to run it, generate rules that output some hints for the user and then fail.

This addresses two problems, both by informing the user about how to accomplish what they're trying to do:
- On a fresh checkout that gets new versions of both the input and generated files, we can't control which order they get written, so the versions of the generated files in the repository may be spuriously out-of-date.  (This can be particularly confusing when trying to build in a freshly-checked-out repository.)
- The built-in-tree versions of in-tree tools are not used by default; somebody who expects the build to be self-contained may not have them installed somewhere in `$PATH`.

A new target, `touch-generated-sid`, is also added to handle spurious timestamp skew.