### PR TITLE
Fix broken README.md symlinks

### DIFF
--- a/calculus/doc/copyright/README.md
+++ b/calculus/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/disp/doc/copyright/README.md
+++ b/disp/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/doc/doc/copyright/README.md
+++ b/doc/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/lexi/doc/copyright/README.md
+++ b/lexi/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/libexds/doc/copyright/README.md
+++ b/libexds/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/libtdf/doc/copyright/README.md
+++ b/libtdf/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/make_err/doc/copyright/README.md
+++ b/make_err/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/make_tdf/doc/copyright/README.md
+++ b/make_tdf/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/osdep/doc/copyright/README.md
+++ b/osdep/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/sid/doc/copyright/README.md
+++ b/sid/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/tcc/doc/copyright/README.md
+++ b/tcc/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/tdf/doc/copyright/README.md
+++ b/tdf/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/tdfc2/doc/copyright/README.md
+++ b/tdfc2/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/tests/doc/copyright/README.md
+++ b/tests/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/tld/doc/copyright/README.md
+++ b/tld/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/tnc/doc/copyright/README.md
+++ b/tnc/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/tpl/doc/copyright/README.md
+++ b/tpl/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/trans/doc/copyright/README.md
+++ b/trans/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md

--- a/tspec/doc/copyright/README.md
+++ b/tspec/doc/copyright/README.md
@@ -1,1 +1,1 @@
-../../../shared/copyright/README
+../../../shared/copyright/README.md


### PR DESCRIPTION
README was changed to README.md but the symlinks weren't updated.