### PR TITLE
Ignore bmake's built-in rules for CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,4 @@ jobs:
 #        run: brew install gcc bmake
 
       - name: Build
-        run: bmake CC=${{ matrix.cc }} TARGETARCH=${{ matrix.target }} -DALLARCH
+        run: bmake -r CC=${{ matrix.cc }} TARGETARCH=${{ matrix.target }} -DALLARCH


### PR DESCRIPTION
ci: ignore bmake's built-in rules