### PR TITLE
Add a Dockerfile and script to run it

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ Build with:
 
 If all goes well, this should give you a working compiler in ./obj.$host-bootstrap/bin
 
+### Building with docker
+
+The Dockerfile defines a base system that can compile the compiler.  You will need
+to build the docker image first, but thereafter you can just run it (without the --build
+parameter).
+
+To build and run the docker image:
+    % ./run-docker.sh --build
+
 
 ## Notes on x86_64
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386
+RUN apt update -y -q && apt upgrade -y -q && apt update -y -q
+RUN apt install -y -q \
+    pmake \
+    g++ \
+    gcc \
+    gcc-multilib \
+    libc6-dev-i386 \
+    linux-libc-dev
+
+RUN mkdir -p /tendra
+
+WORKDIR /tendra
+VOLUME ["/tendra"]
+CMD ["bash"]

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ "$1" = "-b" ] || [ "$1" = "--build" ]; then
+    docker build --tag tendra/build docker
+fi
+docker run --tty --interactive --rm --volume "$(pwd)":/tendra tendra/build


### PR DESCRIPTION
Define a base ubuntu image with the relevant compiler and libraries to
build tendra, and because docker has a pretty steep learning curve
itself, add a shell script that will run it with some pretty handy
non-defaults (like removing the container when you're finished with it).

I've also added some basic instructions.

It's a good start for #45 