### PR TITLE
Revert "shared: mk: improve libc identification routine"

### DIFF
--- a/shared/mk/tendra.makedefs.mk
+++ b/shared/mk/tendra.makedefs.mk
@@ -59,7 +59,7 @@ LDD_VER!=                        \
     | { read v && case "$$v" in  \
         *GNU\ libc*)  echo "$$v" | sed -n 's/^ldd (\(GNU libc\|.* E\?GLIBC .*\)) //p';; \
         *GLIBC*)  echo "$$v" | sed -n 's/^ldd (\(GNU libc\|.* E\?GLIBC .*\)) //p';; \
-        *GNU\ C*) echo "$$v" | sed -n 's/^.*version \(.*\), .*/\1/p' | printf '2';;              \
+        *GNU\ C*) echo "$$v" | sed -n 's/^.*version \(.*\), .*/\1/p';;              \
         MUSL)     echo "$$v" | sed -n 's/^Version \(.*\)/\1/p';;                    \
         *)        echo unknown;; \
     esac }                       \


### PR DESCRIPTION
This reverts commit 43f2933b6091adbf859625d67096881d0f577978.

It seems very wrong, I must have comitted it by accident after debugging
the libc identification routine and it was not caught in review.

Signed-off-by: Filipe Laíns <lains@riseup.net>