### PR TITLE
Fix #62: Multiple definitions for symbols in headers

### DIFF
--- a/lexi/src/lctlexer.c
+++ b/lexi/src/lctlexer.c
@@ -23,6 +23,7 @@
 	typedef int ZTTERMINAL;
 
 	int crt_lct_token;
+	int curr_lct_token;
 	int saved_lct_token;
 
 	char lct_tokbuf[2000];

--- a/lexi/src/lctlexer.h
+++ b/lexi/src/lctlexer.h
@@ -19,12 +19,12 @@
 	typedef FILE *FILE_P_lct;
 
 	extern char lct_tokbuf[];
-	int curr_lct_token;
-	int saved_lct_token;
-	struct lct_ast lct_ast;
+	extern int curr_lct_token;
+	extern int saved_lct_token;
+	extern struct lct_ast lct_ast;
 
-	struct lct_state lct_state;
-	char *lct_token_string;
+	extern struct lct_state lct_state;
+	extern char *lct_token_string;
 
 	#define CURRENT_LCT_TERMINAL curr_lct_token
 	#define ADVANCE_LCT_LEXER    curr_lct_token = lct_next(&lct_state)

--- a/lexi/src/lexer.h
+++ b/lexi/src/lexer.h
@@ -13,11 +13,11 @@
 
 
 	extern char tokbuf[];
-	char *token_end;
-	int curr_lex_token;
-	int saved_lex_token;
-	unsigned int numbuf;
-	struct lxi_state lxi_state;
+	extern char *token_end;
+	extern int curr_lex_token;
+	extern int saved_lex_token;
+	extern unsigned int numbuf;
+	extern struct lxi_state lxi_state;
 
 	typedef FILE *FILE_P;
 


### PR DESCRIPTION
In lexi, when compiling with -fno-common (gcc) there was an error
where certain global variables with tentative definitions would
cause linking errors. This patch properly declares those global
variables in header files as extern and ensure that there is a single
definition for each.