### PR TITLE
Mem corrupt if setting environment variable on CLI

### DIFF
--- a/tcc/src/hash.c
+++ b/tcc/src/hash.c
@@ -152,7 +152,7 @@ envvar_set(struct hash **h, const char *name, const char *value,
 	/* Case 2.  Update with a value */
 	switch (order) {
 	case HASH_ASSIGN:
-		n->value = value;
+		n->value = xstrdup(value);
 		break;
 
 	case HASH_APPEND:


### PR DESCRIPTION
It would appear that there is the possibility for memory
corruption when the machinery for setting environment
variables via the -y option uses the envvar_set function.

I believe that there is a missing xstrdup where the value
of the environment variable is set to x->value when the
operator is a HASH_ASSIGN.

Closes #91