### PR TITLE
Fix Typo in Bitmasking Operations on builtin

### DIFF
--- a/trans/src/common/special/special.c
+++ b/trans/src/common/special/special.c
@@ -91,7 +91,7 @@ special_token(const struct special_tok a[], size_t count,
 	}
 
 	for (i = 0; i < count; i++) {
-		if (a[i].mask && (builtin & ~a[i].mask)) {
+		if (a[i].mask && (~builtin & a[i].mask)) {
 			continue;
 		}
 


### PR DESCRIPTION
In the case where `builtin` has more than one flag set, certain
bitmasking operations are not handled correctly. As a result,
command-line flags that should be obeyed are not.

Fixes #95.