### PR TITLE
Add explicit empty check

### DIFF
--- a/shared/mk/tendra.subdir.mk
+++ b/shared/mk/tendra.subdir.mk
@@ -15,7 +15,7 @@ _TENDRA_SUBDIR_MK_=1
 	@${EXIT} 1;
 .endif
 
-.if ${SUBDIR:Munknown}
+.if ! empty(${SUBDIR:Munknown})
 .BEGIN:
 	@${ECHO} '$${SUBDIR} contains "unknown"; possibly you have an unsupported system.'
 	@${ECHO} 'See shared/mk/tendra.makedefs.mk for supported systems.'


### PR DESCRIPTION
Apparently the `.if` fails with [a `malformed conditional` error](https://github.com/tendra/tendra/issues/101) when `${SUBDIR}` is not set.

This change makes the empty variable modifier check explicit and works around the fail.

Fixes #101 