### PR TITLE
Include header file to declare out_hook_nl

### DIFF
--- a/trans/src/common/main/print.c
+++ b/trans/src/common/main/print.c
@@ -19,6 +19,10 @@
 #include <main/flags.h>
 #include <main/print.h>
 
+#if defined(TRANS_X86)
+#include <local/out.h>
+#endif
+
 static FILE *file;
 
 static const char *margin = "\t"; /* left indent before instructions */


### PR DESCRIPTION
I don't know, these modern C99 compilers complaining that you can't use code before declaring it.

I know macOS isn't a supported platform, but when i try and `bmake -r` in `/trans` i am _stopped_ by some so-called C99 validation:

```
; bmake -r
==> Compiling src/common/main/print.c
cc -D TRANS_X86 -I /Users/drj/prj/tendra/trans/src/x86 -I /Users/drj/prj/tendra/trans/src/common -D TDF_DIAG4 -D DWARF2 -D STABS -I ..  -I /Users/drj/prj/tendra/trans/include  -c print.c -o /Users/drj/prj/tendra/trans/obj/src/x86/_partial/src/common/main/print.o
print.c:49:5: error: implicit declaration of function 'out_hook_nl' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                                out_hook_nl();
                                ^
1 error generated.
*** Error code 1
```

I assume there is no cosmic reason why `print.c` should not include `out.h`, so i added the include. That fixes this compilation error.