### PR TITLE
Fixes function pointers in sid's command line parsing

### DIFF
--- a/sid/src/arg-parse.c
+++ b/sid/src/arg-parse.c
@@ -108,12 +108,12 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 					break;
 
 				case AT_PROC_SWITCH:
-					chosen->proc(option, &closure, chosen->closure, c == '-');
+					((ArgProcPSw)(chosen->proc))(option, &closure, chosen->closure, c == '-');
 					break;
 
 				case AT_IMMEDIATE:
 					if (immediate != NULL) {
-						chosen->proc(option, &closure, chosen->closure, immediate);
+						((ArgProcP1)(chosen->proc))(option, &closure, chosen->closure, immediate);
 					} else {
 						error(ERR_FATAL, "unknown option '%s'", option);
 						UNREACHED;
@@ -123,12 +123,12 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 				case AT_EITHER:
 					if (immediate != NULL) {
 						if (immediate[0]!= '\0') {
-							chosen->proc(option, &closure,
+							((ArgProcP1)(chosen->proc))(option, &closure,
 							chosen->closure, immediate);
 						} else if (tmp_argc > 1) {
 							tmp_argv++;
 							tmp_argc--;
-							chosen->proc(option, &closure,
+							((ArgProcP1)(chosen->proc))(option, &closure,
 							chosen->closure, tmp_argv[0]);
 						} else {
 							error(ERR_FATAL, "missing argument for option '%s'", option);
@@ -144,7 +144,7 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 					if (tmp_argc > 1) {
 						tmp_argv++;
 						tmp_argc--;
-						chosen->proc(option, &closure, chosen->closure,
+						((ArgProcP1)(chosen->proc))(option, &closure, chosen->closure,
 						tmp_argv[0]);
 					} else {
 						error(ERR_FATAL, "missing argument for option '%s'", option);
@@ -160,7 +160,7 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 					if (tmp_argc > 2) {
 						tmp_argv += 2;
 						tmp_argc -= 2;
-						chosen->proc(option, &closure, chosen->closure,
+						((ArgProcP2)(chosen->proc))(option, &closure, chosen->closure,
 						tmp_argv[-1], tmp_argv[0]);
 					} else {
 						error(ERR_FATAL, "missing argument for option '%s'", option);
@@ -172,7 +172,7 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 					if (tmp_argc > 3) {
 						tmp_argv += 3;
 						tmp_argc -= 3;
-						chosen->proc(option, &closure, chosen->closure,
+						((ArgProcP3)(chosen->proc))(option, &closure, chosen->closure,
 						tmp_argv[-2], tmp_argv[-1],
 						tmp_argv[0]);
 					} else {
@@ -214,21 +214,21 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 						break;
 
 					case AT_PROC_SWITCH:
-						chosen->proc(opt, &closure, chosen->closure, c == '-');
+						((ArgProcPSw)(chosen->proc))(opt, &closure, chosen->closure, c == '-');
 						break;
 
 					case AT_IMMEDIATE:
-						chosen->proc(opt, &closure, chosen->closure, opt + 1);
+						((ArgProcP1)(chosen->proc))(opt, &closure, chosen->closure, opt + 1);
 						opt = NULL;
 						break;
 
 					case AT_EITHER:
 						if (opt[1]!= '\0') {
-							chosen->proc(opt, &closure, chosen->closure, opt + 1);
+							((ArgProcP1)(chosen->proc))(opt, &closure, chosen->closure, opt + 1);
 						} else if (tmp_argc > 1) {
 							tmp_argv++;
 							tmp_argc--;
-							chosen->proc(opt, &closure, chosen->closure, tmp_argv[0]);
+							((ArgProcP1)(chosen->proc))(opt, &closure, chosen->closure, tmp_argv[0]);
 						} else {
 							error(ERR_FATAL, "missing argument for option '%s' at '%s'", option, opt);
 							UNREACHED;
@@ -240,7 +240,7 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 						if (tmp_argc > 1) {
 							tmp_argv++;
 							tmp_argc--;
-							chosen->proc(opt, &closure, chosen->closure,
+							((ArgProcP1)(chosen->proc))(opt, &closure, chosen->closure,
 							tmp_argv[0]);
 						} else {
 							error(ERR_FATAL, "missing argument for option '%s' at '%s'", option, opt);
@@ -256,7 +256,7 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 						if (tmp_argc > 2) {
 							tmp_argv += 2;
 							tmp_argc -= 2;
-							chosen->proc(opt, &closure, chosen->closure,
+							((ArgProcP2)(chosen->proc))(opt, &closure, chosen->closure,
 							tmp_argv[-1], tmp_argv[0]);
 						} else {
 							error(ERR_FATAL, "missing argument for option '%s' at '%s'", option, opt);
@@ -268,7 +268,7 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 						if (tmp_argc > 3) {
 							tmp_argv += 3;
 							tmp_argc -= 3;
-							chosen->proc(opt, &closure, chosen->closure,
+							((ArgProcP3)(chosen->proc))(opt, &closure, chosen->closure,
 								tmp_argv[-2], tmp_argv[-1], tmp_argv[0]);
 						} else {
 							error(ERR_FATAL, "missing argument for option '%s' at '%s'", option, opt);

--- a/sid/src/arg-parse.h
+++ b/sid/src/arg-parse.h
@@ -36,7 +36,7 @@
 #include <exds/ostream.h>
 
 /*
- * This is the type of the an option.  The constants have the following
+ * This is the type of an option.  The constants have the following
  * meanings:
  *
  *	AT_SWITCH

--- a/sid/src/arg-parse.h
+++ b/sid/src/arg-parse.h
@@ -173,14 +173,14 @@ typedef void(*ArgProcP3)(char *, ArgUsageT *, void *, char *, char *, char *);
  * illegal for an option to have neither a long form or a short form.
  */
 typedef struct ArgListT {
-    char *          name;
+    char           *name;
     char            short_name;
-    ArgTypeT            type;
-    ArgProcP            proc;
-    void *          closure;
+    ArgTypeT        type;
+    ArgProcP        proc;
+    void           *closure;
     union {
-    char *      name;
-    EStringT *        message;
+	char       *name;
+	EStringT   *message;
     } u;
 } ArgListT;
 
@@ -193,7 +193,7 @@ typedef struct ArgListT {
  * called once on each list.  The named strings used should be interned before
  * this function is called.
  */
-void		arg_parse_intern_descriptions(ArgListT * arg_list);
+void		arg_parse_intern_descriptions(ArgListT *arg_list);
 
 /*
  * Exceptions:	XX_dalloc_no_memory, XX_ostream_write_error

--- a/sid/src/arg-parse.h
+++ b/sid/src/arg-parse.h
@@ -138,7 +138,11 @@ typedef struct ArgUsageT {
  * Because of union initialisation problems, the latter arguments of this
  * function are untyped.
  */
-typedef void(*ArgProcP)(char *, ArgUsageT *, void *, ...);
+typedef void(*ArgProcP)(char *, ArgUsageT *, void *);
+typedef void(*ArgProcPSw)(char *, ArgUsageT *, void *, bool);
+typedef void(*ArgProcP1)(char *, ArgUsageT *, void *, char *);
+typedef void(*ArgProcP2)(char *, ArgUsageT *, void *, char *, char *);
+typedef void(*ArgProcP3)(char *, ArgUsageT *, void *, char *, char *, char *);
 
 /*
  * This is the type of an entry in an option list.  A vector of such entries

--- a/tld/src/arg-parse.c
+++ b/tld/src/arg-parse.c
@@ -108,12 +108,12 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 					break;
 
 				case AT_PROC_SWITCH:
-					(*(chosen->proc))(option, &closure, chosen->closure, c == '-');
+					((ArgProcPSw)(chosen->proc))(option, &closure, chosen->closure, c == '-');
 					break;
 
 				case AT_IMMEDIATE:
 					if (immediate != NULL) {
-						(*(chosen->proc))(option, &closure, chosen->closure, immediate);
+						((ArgProcP1)(chosen->proc))(option, &closure, chosen->closure, immediate);
 					} else {
 						error(ERR_FATAL, "unknown option '%s'", option);
 						UNREACHED;
@@ -123,13 +123,13 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 				case AT_EITHER:
 					if (immediate != NULL) {
 						if (immediate[0]!= '\0') {
-							(*(chosen->proc))(option, &closure,
-								chosen->closure, immediate);
+							((ArgProcP1)(chosen->proc))(option, &closure,
+							chosen->closure, immediate);
 						} else if (tmp_argc > 1) {
 							tmp_argv++;
 							tmp_argc--;
-							(*(chosen->proc))(option, &closure,
-								chosen->closure, tmp_argv[0]);
+							((ArgProcP1)(chosen->proc))(option, &closure,
+							chosen->closure, tmp_argv[0]);
 						} else {
 							error(ERR_FATAL, "missing argument for option '%s'", option);
 							UNREACHED;
@@ -144,8 +144,8 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 					if (tmp_argc > 1) {
 						tmp_argv++;
 						tmp_argc--;
-						(*(chosen->proc))(option, &closure, chosen->closure,
-							tmp_argv[0]);
+						((ArgProcP1)(chosen->proc))(option, &closure, chosen->closure,
+						tmp_argv[0]);
 					} else {
 						error(ERR_FATAL, "missing argument for option '%s'", option);
 						UNREACHED;
@@ -153,15 +153,15 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 					break;
 
 				case AT_EMPTY:
-					(*(chosen->proc))(option, &closure, chosen->closure);
+					chosen->proc(option, &closure, chosen->closure);
 					break;
 
 				case AT_FOLLOWING2:
 					if (tmp_argc > 2) {
 						tmp_argv += 2;
 						tmp_argc -= 2;
-						(*(chosen->proc))(option, &closure, chosen->closure,
-							tmp_argv[-1], tmp_argv[0]);
+						((ArgProcP2)(chosen->proc))(option, &closure, chosen->closure,
+						tmp_argv[-1], tmp_argv[0]);
 					} else {
 						error(ERR_FATAL, "missing argument for option '%s'", option);
 						UNREACHED;
@@ -172,9 +172,9 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 					if (tmp_argc > 3) {
 						tmp_argv += 3;
 						tmp_argc -= 3;
-						(*(chosen->proc))(option, &closure, chosen->closure,
-							tmp_argv[-2], tmp_argv[-1],
-							tmp_argv[0]);
+						((ArgProcP3)(chosen->proc))(option, &closure, chosen->closure,
+						tmp_argv[-2], tmp_argv[-1],
+						tmp_argv[0]);
 					} else {
 						error(ERR_FATAL, "missing argument for option '%s'", option);
 						UNREACHED;
@@ -214,21 +214,21 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 						break;
 
 					case AT_PROC_SWITCH:
-						(*(chosen->proc))(opt, &closure, chosen->closure, c == '-');
+						((ArgProcPSw)(chosen->proc))(opt, &closure, chosen->closure, c == '-');
 						break;
 
 					case AT_IMMEDIATE:
-						(*(chosen->proc))(opt, &closure, chosen->closure, opt + 1);
+						((ArgProcP1)(chosen->proc))(opt, &closure, chosen->closure, opt + 1);
 						opt = NULL;
 						break;
 
 					case AT_EITHER:
 						if (opt[1]!= '\0') {
-							(*(chosen->proc))(opt, &closure, chosen->closure, opt + 1);
+							((ArgProcP1)(chosen->proc))(opt, &closure, chosen->closure, opt + 1);
 						} else if (tmp_argc > 1) {
 							tmp_argv++;
 							tmp_argc--;
-							(*(chosen->proc))(opt, &closure, chosen->closure, tmp_argv[0]);
+							((ArgProcP1)(chosen->proc))(opt, &closure, chosen->closure, tmp_argv[0]);
 						} else {
 							error(ERR_FATAL, "missing argument for option '%s' at '%s'", option, opt);
 							UNREACHED;
@@ -240,8 +240,8 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 						if (tmp_argc > 1) {
 							tmp_argv++;
 							tmp_argc--;
-							(*(chosen->proc))(opt, &closure, chosen->closure,
-								tmp_argv[0]);
+							((ArgProcP1)(chosen->proc))(opt, &closure, chosen->closure,
+							tmp_argv[0]);
 						} else {
 							error(ERR_FATAL, "missing argument for option '%s' at '%s'", option, opt);
 							UNREACHED;
@@ -249,15 +249,15 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 						break;
 
 					case AT_EMPTY:
-						(*(chosen->proc))(opt, &closure, chosen->closure);
+						chosen->proc(opt, &closure, chosen->closure);
 						break;
 
 					case AT_FOLLOWING2:
 						if (tmp_argc > 2) {
 							tmp_argv += 2;
 							tmp_argc -= 2;
-							(*(chosen->proc))(opt, &closure, chosen->closure,
-								tmp_argv[-1], tmp_argv[0]);
+							((ArgProcP2)(chosen->proc))(opt, &closure, chosen->closure,
+							tmp_argv[-1], tmp_argv[0]);
 						} else {
 							error(ERR_FATAL, "missing argument for option '%s' at '%s'", option, opt);
 							UNREACHED;
@@ -268,7 +268,7 @@ arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 						if (tmp_argc > 3) {
 							tmp_argv += 3;
 							tmp_argc -= 3;
-							(*(chosen->proc))(opt, &closure, chosen->closure,
+							((ArgProcP3)(chosen->proc))(opt, &closure, chosen->closure,
 								tmp_argv[-2], tmp_argv[-1], tmp_argv[0]);
 						} else {
 							error(ERR_FATAL, "missing argument for option '%s' at '%s'", option, opt);

--- a/tld/src/arg-parse.c
+++ b/tld/src/arg-parse.c
@@ -24,301 +24,300 @@
 void
 arg_parse_intern_descriptions(ArgListT *arg_list)
 {
-    while ((arg_list->name != NULL) ||
-	  (arg_list->short_name != '\0')) {
-	EStringT *estring = error_lookup_string(arg_list->u.name);
+	while (arg_list->name != NULL || arg_list->short_name != '\0') {
+		EStringT *estring = error_lookup_string(arg_list->u.name);
 
-	assert(estring != NULL);
-	arg_list->u.message = estring;
-	arg_list++;
-    }
+		assert(estring != NULL);
+		arg_list->u.message = estring;
+		arg_list++;
+	}
 }
 
 int
-arg_parse_arguments(ArgListT *arg_list,			     EStringT *usage ,
-			     int      argc ,
-			     char   **argv)
+arg_parse_arguments(ArgListT *arg_list, EStringT *usage, int argc, char **argv)
 {
-    int       tmp_argc = argc;
-    char    **tmp_argv = argv;
-    ArgUsageT closure;
+	int       tmp_argc = argc;
+	char    **tmp_argv = argv;
+	ArgUsageT closure;
 
-    closure.usage    = error_string_contents(usage);
-    closure.arg_list = arg_list;
-    while (tmp_argc) {
-	char * option = (tmp_argv[0]);
-	char     c      = (option[0]);
+	closure.usage    = error_string_contents(usage);
+	closure.arg_list = arg_list;
+	while (tmp_argc) {
+		char *option = tmp_argv[0];
+		char  c      = option[0];
 
-	if ((((c == '-') && (option[1] == '-')) ||
-	    ((c == '+') && (option[1] == '+'))) && (option[2] == '\0')) {
-	    return argc - tmp_argc + 1;
-	} else if (((c == '-') && (option[1] == '-')) ||
-		  ((c == '+') && (option[1] == '+'))) {
-	    ArgListT *tmp_list  = arg_list;
-	    ArgListT *chosen    = NULL;
-	    unsigned matches   = 0;
-	    char * immediate = NULL;
+		if (((c == '-' && option[1] == '-')
+				|| (c == '+' && option[1] == '+'))
+			&& option[2] == '\0') {
+			return argc - tmp_argc + 1;
+		} else if ((c == '-' && option[1] == '-')
+			|| (c == '+' && option[1] == '+')) {
 
-	    while ((tmp_list->name != NULL) ||
-		  (tmp_list->short_name != '\0')) {
-		char * opt = (tmp_list->name);
-		char * arg = (& (option[2]));
+			ArgListT *tmp_list  = arg_list;
+			ArgListT *chosen    = NULL;
+			unsigned matches   = 0;
+			char *immediate = NULL;
 
-		if (opt != NULL) {
-		    char optch;
-		    char argch;
+			while (tmp_list->name != NULL || tmp_list->short_name != '\0') {
+				char *opt = tmp_list->name;
+				char *arg = &option[2];
 
-		    do {
-			optch = (*opt++);
-			argch = (*arg++);
-		    } while (optch && argch && (optch == argch));
-		    if (optch == argch) {
-			chosen    = tmp_list;
-			matches   = 1;
-			immediate = (arg - 1);
-			break;
-		    } else if ((optch == '\0') &&
-			      (((tmp_list->type) == AT_IMMEDIATE) ||
-				((tmp_list->type) == AT_EITHER))) {
-			chosen    = tmp_list;
-			matches   = 1;
-			immediate = (arg - 1);
-			break;
-		    } else if (argch == '\0') {
-			chosen = tmp_list;
-			matches++;
-		    }
-		}
-		tmp_list++;
-	    }
-	    if (matches == 0) {
-		error(ERR_FATAL, "unknown option '%s'", option);
-		UNREACHED;
-	    } else if (matches > 1) {
-		error(ERR_FATAL, "ambiguous option '%s'", option);
-		UNREACHED;
-	    } else {
-		switch (chosen->type) {
-		  case AT_SWITCH:
-		   (*((bool *)(chosen->closure))) = (c == '-');
-		    break;
-		  case AT_NEG_SWITCH:
-		   (*((bool *)(chosen->closure))) = (c == '+');
-		    break;
-		  case AT_PROC_SWITCH:
-		   (*(chosen->proc))(option, &closure, chosen->closure,
-				       c == '-');
-		    break;
-		  case AT_IMMEDIATE:
-		    if (immediate != NULL) {
-			(*(chosen->proc))(option, &closure, chosen->closure,
-					   immediate);
-		    } else {
+				if (opt != NULL) {
+					char optch;
+					char argch;
+
+					do {
+						optch = *opt++;
+						argch = *arg++;
+					} while (optch && argch && optch == argch);
+
+					if (optch == argch) {
+						chosen    = tmp_list;
+						matches   = 1;
+						immediate = (arg - 1);
+						break;
+					} else if (optch == '\0'
+						&& (tmp_list->type == AT_IMMEDIATE
+							|| tmp_list->type == AT_EITHER)) {
+						chosen    = tmp_list;
+						matches   = 1;
+						immediate = (arg - 1);
+						break;
+					} else if (argch == '\0') {
+						chosen = tmp_list;
+						matches++;
+					}
+				}
+				tmp_list++;
+			}
+
+			if (matches == 0) {
+				error(ERR_FATAL, "unknown option '%s'", option);
+				UNREACHED;
+			} else if (matches > 1) {
+				error(ERR_FATAL, "ambiguous option '%s'", option);
+				UNREACHED;
+			} else {
+				switch (chosen->type) {
+				case AT_SWITCH:
+					*((bool *) (chosen->closure)) = (c == '-');
+					break;
+
+				case AT_NEG_SWITCH:
+					*((bool *) (chosen->closure)) = (c == '+');
+					break;
+
+				case AT_PROC_SWITCH:
+					(*(chosen->proc))(option, &closure, chosen->closure, c == '-');
+					break;
+
+				case AT_IMMEDIATE:
+					if (immediate != NULL) {
+						(*(chosen->proc))(option, &closure, chosen->closure, immediate);
+					} else {
+						error(ERR_FATAL, "unknown option '%s'", option);
+						UNREACHED;
+					}
+					break;
+
+				case AT_EITHER:
+					if (immediate != NULL) {
+						if (immediate[0]!= '\0') {
+							(*(chosen->proc))(option, &closure,
+								chosen->closure, immediate);
+						} else if (tmp_argc > 1) {
+							tmp_argv++;
+							tmp_argc--;
+							(*(chosen->proc))(option, &closure,
+								chosen->closure, tmp_argv[0]);
+						} else {
+							error(ERR_FATAL, "missing argument for option '%s'", option);
+							UNREACHED;
+						}
+					} else {
+						error(ERR_FATAL, "unknown option '%s'", option);
+						UNREACHED;
+					}
+					break;
+
+				case AT_FOLLOWING:
+					if (tmp_argc > 1) {
+						tmp_argv++;
+						tmp_argc--;
+						(*(chosen->proc))(option, &closure, chosen->closure,
+							tmp_argv[0]);
+					} else {
+						error(ERR_FATAL, "missing argument for option '%s'", option);
+						UNREACHED;
+					}
+					break;
+
+				case AT_EMPTY:
+					(*(chosen->proc))(option, &closure, chosen->closure);
+					break;
+
+				case AT_FOLLOWING2:
+					if (tmp_argc > 2) {
+						tmp_argv += 2;
+						tmp_argc -= 2;
+						(*(chosen->proc))(option, &closure, chosen->closure,
+							tmp_argv[-1], tmp_argv[0]);
+					} else {
+						error(ERR_FATAL, "missing argument for option '%s'", option);
+						UNREACHED;
+					}
+					break;
+
+				case AT_FOLLOWING3:
+					if (tmp_argc > 3) {
+						tmp_argv += 3;
+						tmp_argc -= 3;
+						(*(chosen->proc))(option, &closure, chosen->closure,
+							tmp_argv[-2], tmp_argv[-1],
+							tmp_argv[0]);
+					} else {
+						error(ERR_FATAL, "missing argument for option '%s'", option);
+						UNREACHED;
+					}
+					break;
+				}
+			}
+		} else if ((c == '-' && option[1] == '+')
+			|| (c == '+' && option[1] == '-')
+			|| (c == '-' && option[1] == '\0')
+			|| (c == '+' && option[1] == '\0')) {
 			error(ERR_FATAL, "unknown option '%s'", option);
 			UNREACHED;
-		    }
-		    break;
-		  case AT_EITHER:
-		    if (immediate != NULL) {
-			if (immediate[0]!= '\0') {
-			   (*(chosen->proc))(option, &closure,
-					       chosen->closure, immediate);
-			} else if (tmp_argc > 1) {
-			    tmp_argv++;
-			    tmp_argc--;
-			   (*(chosen->proc))(option, &closure,
-					       chosen->closure, tmp_argv[0]);
-			} else {
-				error(ERR_FATAL, 
-				"missing argument for option '%s'", option);
-			    UNREACHED;
-			}
-		    } else {
-			error(ERR_FATAL, "unknown option '%s'", option);
-			UNREACHED;
-		    }
-		    break;
-		  case AT_FOLLOWING:
-		    if (tmp_argc > 1) {
-			tmp_argv++;
-			tmp_argc--;
-			(*(chosen->proc))(option, &closure, chosen->closure,
-					   tmp_argv[0]);
-		    } else {
-			error(ERR_FATAL, "missing argument for option '%s'", 
-				option);
-			UNREACHED;
-		    }
-		    break;
-		  case AT_EMPTY:
-		   (*(chosen->proc))(option, &closure, chosen->closure);
-		    break;
-		  case AT_FOLLOWING2:
-		    if (tmp_argc > 2) {
-			tmp_argv += 2;
-			tmp_argc -= 2;
-			(*(chosen->proc))(option, &closure, chosen->closure,
-					   tmp_argv[-1], tmp_argv[0]);
-		    } else {
-			error(ERR_FATAL, "missing argument for option '%s'", 
-				option);
-			UNREACHED;
-		    }
-		    break;
-		  case AT_FOLLOWING3:
-		    if (tmp_argc > 3) {
-			tmp_argv += 3;
-			tmp_argc -= 3;
-			(*(chosen->proc))(option, &closure, chosen->closure,
-					   tmp_argv[-2], tmp_argv[-1],
-					   tmp_argv[0]);
-		    } else {
-			error(ERR_FATAL, "missing argument for option '%s'", 
-				option);
-			UNREACHED;
-		    }
-		    break;
-		}
-	    }
-	} else if (((c == '-') && (option[1] == '+')) ||
-		  ((c == '+') && (option[1] == '-')) ||
-		  ((c == '-') && (option[1] == '\0')) ||
-		  ((c == '+') && (option[1] == '\0'))) {
-		error(ERR_FATAL, "unknown option '%s'", option);
-	    UNREACHED;
-	} else if ((c == '-') || (c == '+')) {
-	    char * opt = & (option[1]);
+		} else if (c == '-' || c == '+') {
+			char *opt = &option[1];
 
-	    while ((opt != NULL) && (*opt != '\0')) {
-		ArgListT *tmp_list = arg_list;
-		ArgListT *chosen   = NULL;
+			while (opt != NULL && *opt != '\0') {
+				ArgListT *tmp_list = arg_list;
+				ArgListT *chosen   = NULL;
 
-		while ((tmp_list->name != NULL) ||
-		      (tmp_list->short_name != '\0')) {
-		    if (tmp_list->short_name == *opt) {
-			chosen = tmp_list;
-			break;
-		    }
-		    tmp_list++;
-		}
-		if (chosen) {
-		    switch (chosen->type) {
-		      case AT_SWITCH:
-			(*((bool *)(chosen->closure))) = (c == '-');
-			break;
-		      case AT_NEG_SWITCH:
-			(*((bool *)(chosen->closure))) = (c == '+');
-			break;
-		      case AT_PROC_SWITCH:
-			(*(chosen->proc))(opt, &closure, chosen->closure,
-					   c == '-');
-			break;
-		      case AT_IMMEDIATE:
-			(*(chosen->proc))(opt, &closure, chosen->closure,
-					   opt + 1);
-			opt = NULL;
-			break;
-		      case AT_EITHER:
-			if (opt[1]!= '\0') {
-			   (*(chosen->proc))(opt, &closure, chosen->closure,
-					       opt + 1);
-			} else if (tmp_argc > 1) {
-			    tmp_argv++;
-			    tmp_argc--;
-			   (*(chosen->proc))(opt, &closure, chosen->closure,
-					       tmp_argv[0]);
-			} else {
-				error(ERR_FATAL, 
-			"missing argument for option '%s' at '%s'", option, opt);
-			    UNREACHED;
+				while (tmp_list->name != NULL || tmp_list->short_name != '\0') {
+					if (tmp_list->short_name == *opt) {
+						chosen = tmp_list;
+						break;
+					}
+					tmp_list++;
+				}
+
+				if (chosen) {
+					switch (chosen->type) {
+					case AT_SWITCH:
+						*((bool *) chosen->closure) = (c == '-');
+						break;
+
+					case AT_NEG_SWITCH:
+						*((bool *) chosen->closure) = (c == '+');
+						break;
+
+					case AT_PROC_SWITCH:
+						(*(chosen->proc))(opt, &closure, chosen->closure, c == '-');
+						break;
+
+					case AT_IMMEDIATE:
+						(*(chosen->proc))(opt, &closure, chosen->closure, opt + 1);
+						opt = NULL;
+						break;
+
+					case AT_EITHER:
+						if (opt[1]!= '\0') {
+							(*(chosen->proc))(opt, &closure, chosen->closure, opt + 1);
+						} else if (tmp_argc > 1) {
+							tmp_argv++;
+							tmp_argc--;
+							(*(chosen->proc))(opt, &closure, chosen->closure, tmp_argv[0]);
+						} else {
+							error(ERR_FATAL, "missing argument for option '%s' at '%s'", option, opt);
+							UNREACHED;
+						}
+						opt = NULL;
+						break;
+
+					case AT_FOLLOWING:
+						if (tmp_argc > 1) {
+							tmp_argv++;
+							tmp_argc--;
+							(*(chosen->proc))(opt, &closure, chosen->closure,
+								tmp_argv[0]);
+						} else {
+							error(ERR_FATAL, "missing argument for option '%s' at '%s'", option, opt);
+							UNREACHED;
+						}
+						break;
+
+					case AT_EMPTY:
+						(*(chosen->proc))(opt, &closure, chosen->closure);
+						break;
+
+					case AT_FOLLOWING2:
+						if (tmp_argc > 2) {
+							tmp_argv += 2;
+							tmp_argc -= 2;
+							(*(chosen->proc))(opt, &closure, chosen->closure,
+								tmp_argv[-1], tmp_argv[0]);
+						} else {
+							error(ERR_FATAL, "missing argument for option '%s' at '%s'", option, opt);
+							UNREACHED;
+						}
+						break;
+
+					case AT_FOLLOWING3:
+						if (tmp_argc > 3) {
+							tmp_argv += 3;
+							tmp_argc -= 3;
+							(*(chosen->proc))(opt, &closure, chosen->closure,
+								tmp_argv[-2], tmp_argv[-1], tmp_argv[0]);
+						} else {
+							error(ERR_FATAL, "missing argument for option '%s' at '%s'", option, opt);
+							UNREACHED;
+						}
+						break;
+					}
+				} else {
+					error(ERR_FATAL, "unknown short option '%s' at '%s'", option, opt);
+					UNREACHED;
+				}
+
+				if (opt) {
+					opt++;
+				}
 			}
-			opt = NULL;
-			break;
-		      case AT_FOLLOWING:
-			if (tmp_argc > 1) {
-			    tmp_argv++;
-			    tmp_argc--;
-			   (*(chosen->proc))(opt, &closure, chosen->closure,
-					       tmp_argv[0]);
-			} else {
-				error(ERR_FATAL, "missing argument for "
-					"option '%s' at '%s'", 
-				option, opt);
-			    UNREACHED;
-			}
-			break;
-		      case AT_EMPTY:
-			(*(chosen->proc))(opt, &closure, chosen->closure);
-			break;
-		      case AT_FOLLOWING2:
-			if (tmp_argc > 2) {
-			    tmp_argv += 2;
-			    tmp_argc -= 2;
-			   (*(chosen->proc))(opt, &closure, chosen->closure,
-					       tmp_argv[-1], tmp_argv[0]);
-			} else {
-				error(ERR_FATAL, "missing argument for "
-					"option '%s' at '%s'", 
-				option, opt);
-			    UNREACHED;
-			}
-			break;
-		      case AT_FOLLOWING3:
-			if (tmp_argc > 3) {
-			    tmp_argv += 3;
-			    tmp_argc -= 3;
-			   (*(chosen->proc))(opt, &closure, chosen->closure,
-					       tmp_argv[-2], tmp_argv[-1],
-					       tmp_argv[0]);
-			} else {
-				error(ERR_FATAL, "missing argument for "
-					"option '%s' at '%s'", 
-				option, opt);
-			    UNREACHED;
-			}
-			break;
-		    }
 		} else {
-			error(ERR_FATAL, "unknown short option '%s' at '%s'", 
-				option, opt);
-		    UNREACHED;
+			return argc - tmp_argc;
 		}
-		if (opt) {
-		    opt++;
-		}
-	    }
-	} else {
-	    return argc - tmp_argc;
+		tmp_argv++;
+		tmp_argc--;
 	}
-	tmp_argv++;
-	tmp_argc--;
-    }
-    return argc;
+
+	return argc;
 }
 
 void
-write_arg_usage(OStreamT * ostream,			 ArgUsageT *closure)
+write_arg_usage(OStreamT *ostream, ArgUsageT *closure)
 {
-    const char *usage  = (closure->usage);
-    ArgListT *arg_list = (closure->arg_list);
+	const char *usage  = closure->usage;
+	ArgListT *arg_list = closure->arg_list;
 
-    write_cstring(ostream, usage);
-    while ((arg_list->name != NULL) ||
-	  (arg_list->short_name != '\0')) {
-	const char * desc = error_string_contents(arg_list->u.message);
+	write_cstring(ostream, usage);
+	while (arg_list->name != NULL || arg_list->short_name != '\0') {
+		const char *desc = error_string_contents(arg_list->u.message);
 
-	if (arg_list->name) {
-	    write_newline(ostream);
-	    write_cstring(ostream, "    {--|++}");
-	    write_cstring(ostream, arg_list->name);
-	    write_cstring(ostream, desc);
+		if (arg_list->name) {
+			write_newline(ostream);
+			write_cstring(ostream, "    {--|++}");
+			write_cstring(ostream, arg_list->name);
+			write_cstring(ostream, desc);
+		}
+
+		if (arg_list->short_name != '\0') {
+			write_newline(ostream);
+			write_cstring(ostream, "    {-|+}");
+			write_char(ostream, arg_list->short_name);
+			write_cstring(ostream, desc);
+		}
+		arg_list++;
 	}
-	if (arg_list->short_name != '\0') {
-	    write_newline(ostream);
-	    write_cstring(ostream, "    {-|+}");
-	    write_char(ostream, arg_list->short_name);
-	    write_cstring(ostream, desc);
-	}
-	arg_list++;
-    }
 }

--- a/tld/src/arg-parse.h
+++ b/tld/src/arg-parse.h
@@ -123,6 +123,8 @@ typedef enum {
 	AT_FOLLOWING3
 } ArgTypeT;
 
+struct ArgListT;
+
 /*
  * This is the type of argument to be passed to ``write_arg_usage''.
  */

--- a/tld/src/arg-parse.h
+++ b/tld/src/arg-parse.h
@@ -138,7 +138,11 @@ typedef struct ArgUsageT {
  * Because of union initialisation problems, the latter arguments of this
  * function are untyped.
  */
-typedef void(*ArgProcP)(char *, ArgUsageT *, void *, ...);
+typedef void(*ArgProcP)(char *, ArgUsageT *, void *);
+typedef void(*ArgProcPSw)(char *, ArgUsageT *, void *, bool);
+typedef void(*ArgProcP1)(char *, ArgUsageT *, void *, char *);
+typedef void(*ArgProcP2)(char *, ArgUsageT *, void *, char *, char *);
+typedef void(*ArgProcP3)(char *, ArgUsageT *, void *, char *, char *, char *);
 
 /*
  * This is the type of an entry in an option list.  A vector of such entries

--- a/tld/src/arg-parse.h
+++ b/tld/src/arg-parse.h
@@ -36,88 +36,90 @@
 #include <exds/ostream.h>
 
 /*
- * This is the type of an option.
+ * This is the type of an option.  The constants have the following
+ * meanings:
+ *
+ *	AT_SWITCH
+ *
+ * This is the type of a switch option.  The procedure value should be null.
+ * The closure should be a pointer to a boolean.  If the option character is a
+ * '-' then the boolean is set.  If the option character is '+' then the
+ * boolean is reset.
+ *
+ *	AT_NEG_SWITCH
+ *
+ * This is the type of a negated switch option. The procedure value should be
+ * null. The closure should be a pointer to a boolean.  If the option
+ * character is a '-' then the boolean is reset.  If the option character is
+ * '+' then the boolean is set.
+ *
+ *	AT_PROC_SWITCH
+ *
+ * This is the type of a switch option that needs some extra work to be
+ * performed.  The procedure will be called with the option that was selected,
+ * the error closure, the option closure, and a boolean (true if the option
+ * character is '-', false otherwise).
+ *
+ *	AT_IMMEDIATE
+ *
+ * This is the type of an option with one immediate argument.  No shortest
+ * prefix matching will be used for immediate arguments.  The procedure will
+ * be called with the option that was selected, the error closure, the option
+ * closure, and the argument to the option.  This type of argument should
+ * appear at the end of the argument list that is passed to the
+ * ``arg_parse_arguments'' function, as it may cause problems with shortest
+ * prefix matching otherwise.
+ *
+ *	AT_EITHER
+ *
+ * This is the type of an option with one argument. If an immediate argument
+ * exists, then that is used.  If no immediate argument exists, then the
+ * following argument is used.  No shortest prefix matching will be used for
+ * either arguments.  The procedure will be called with the option that was
+ * selected, the error closure, the option closure, and the argument to the
+ * option.  This type of argument should appear at the end of the argument
+ * list that is passed to the ``arg_parse_arguments'' function, as it may
+ * cause problems with shortest prefix matching otherwise.
+ *
+ *	AT_FOLLOWING
+ *
+ * This is the type of an option with one following argument.  The procedure
+ * will be called with the option that was selected, the error closure, the
+ * option closure, and the argument to the option.
+ *
+ *	AT_EMPTY
+ *
+ * This is the type of an option with no argument.  The procedure will be
+ * called with the option that was selected, the error closure, and the option
+ * closure.
+ *
+ *	AT_FOLLOWING2
+ *
+ * This is the type of an option with two following arguments.  The procedure
+ * will be called with the option that was selected, the error closure, the
+ * option closure, and the arguments to the option.
+ *
+ *	AT_FOLLOWING3
+ *
+ * This is the type of an option with three following arguments.  The
+ * procedure will be called with the option that was selected, the error
+ * closure, the option closure, and the arguments to the option.
+ *
+ * Note that if a matched option is a short option, then the current position
+ * is passed to the option handling procedure as the option name.  For long
+ * options, the entire option string is passed.  If the handler is interested
+ * in the option name, it should check the start of this string: if it is '-'
+ * or '+' it should be a long option; otherwise it should be a short option.
  */
 typedef enum {
-	/*
-	 * This is the type of a switch option.  The procedure value should be null.
-	 * The closure should be a pointer to a boolean.  If the option character is a
-	 * '-' then the boolean is set.  If the option character is '+' then the
-	 * boolean is reset.
-	 */
 	AT_SWITCH,
-
-	/*
-	 * This is the type of a negated switch option. The procedure value should be
-	 * null. The closure should be a pointer to a boolean.  If the option
-	 * character is a '-' then the boolean is reset.  If the option character is
-	 * '+' then the boolean is set.
-	 */
 	AT_NEG_SWITCH,
-
-	/*
-	 * This is the type of a switch option that needs some extra work to be
-	 * performed.  The procedure will be called with the option that was selected,
-	 * the error closure, the option closure, and a boolean (true if the option
-	 * character is '-', false otherwise).
-	 */
 	AT_PROC_SWITCH,
-
-	/*
-	 * This is the type of an option with one immediate argument.  No shortest
-	 * prefix matching will be used for immediate arguments.  The procedure will
-	 * be called with the option that was selected, the error closure, the option
-	 * closure, and the argument to the option.  This type of argument should
-	 * appear at the end of the argument list that is passed to the
-	 * ``arg_parse_arguments'' function, as it may cause problems with shortest
-	 * prefix matching otherwise.
-	 */
 	AT_IMMEDIATE,
-
-	/*
-	 * This is the type of an option with one argument. If an immediate argument
-	 * exists, then that is used.  If no immediate argument exists, then the
-	 * following argument is used.  No shortest prefix matching will be used for
-	 * either arguments.  The procedure will be called with the option that was
-	 * selected, the error closure, the option closure, and the argument to the
-	 * option.  This type of argument should appear at the end of the argument
-	 * list that is passed to the ``arg_parse_arguments'' function, as it may
-	 * cause problems with shortest prefix matching otherwise.
-	 */
 	AT_EITHER,
-
-	/*
-	 * This is the type of an option with one following argument.  The procedure
-	 * will be called with the option that was selected, the error closure, the
-	 * option closure, and the argument to the option.
-	 */
 	AT_FOLLOWING,
-
-	/*
-	 * This is the type of an option with no argument.  The procedure will be
-	 * called with the option that was selected, the error closure, and the option
-	 * closure.
-	 */
 	AT_EMPTY,
-
-	/*
-	 * This is the type of an option with two following arguments.  The procedure
-	 * will be called with the option that was selected, the error closure, the
-	 * option closure, and the arguments to the option.
-	 */
 	AT_FOLLOWING2,
-
-	/*
-	 * This is the type of an option with three following arguments.  The
-	 * procedure will be called with the option that was selected, the error
-	 * closure, the option closure, and the arguments to the option.
-	 *
-	 * Note that if a matched option is a short option, then the current position
-	 * is passed to the option handling procedure as the option name.  For long
-	 * options, the entire option string is passed.  If the handler is interested
-	 * in the option name, it should check the start of this string: if it is '-'
-	 * or '+' it should be a long option; otherwise it should be a short option.
-	 */
 	AT_FOLLOWING3
 } ArgTypeT;
 

--- a/tld/src/arg-parse.h
+++ b/tld/src/arg-parse.h
@@ -189,8 +189,7 @@ typedef struct ArgListT {
  * called once on each list.  The named strings used should be interned before
  * this function is called.
  */
-extern void			arg_parse_intern_descriptions
-(ArgListT *);
+void		arg_parse_intern_descriptions(ArgListT *arg_list);
 
 /*
  * Exceptions:	XX_dalloc_no_memory, XX_ostream_write_error
@@ -204,8 +203,7 @@ extern void			arg_parse_intern_descriptions
  * this function.  The function returns the number of elements of the list
  * that it parsed.
  */
-extern int			arg_parse_arguments
-(ArgListT *, EStringT *, int, char **);
+int		arg_parse_arguments(ArgListT *, EStringT *, int, char **);
 
 /*
  * Exceptions:	XX_dalloc_no_memory, XX_ostream_write_error
@@ -213,8 +211,7 @@ extern int			arg_parse_arguments
  * This function can be used to write out a usage message based upon the usage
  * information supplied.
  */
-extern void			write_arg_usage
-(OStreamT *, ArgUsageT *);
+void		write_arg_usage(OStreamT *, ArgUsageT *);
 
 /*
  * This macro should be used to terminate an option list.

--- a/tld/src/arg-parse.h
+++ b/tld/src/arg-parse.h
@@ -150,8 +150,8 @@ typedef void(*ArgProcP)(char *, ArgUsageT *, void *, ...);
  * field (a pointer to some arbritary data used by the procedure), and a
  * description field (the name of a named string that describes how the option
  * is used - see the file "error.h" for more information on named strings).
- * The description field should be surrounded by braces for union initialisation.
- * The named strings used in the description fields
+ * The description field should be surrounded by braces for union
+ * initialisation.  The named strings used in the description fields
  * should themselves be interned before the ``arg_parse_arguments'' function
  * is called.  A typical argument list definition would be something like the
  * following:
@@ -169,14 +169,14 @@ typedef void(*ArgProcP)(char *, ArgUsageT *, void *, ...);
  * illegal for an option to have neither a long form or a short form.
  */
 typedef struct ArgListT {
-    char *			name;
-    char			short_name;
-    ArgTypeT			type;
-    ArgProcP			proc;
-    void *			closure;
+    char           *name;
+    char            short_name;
+    ArgTypeT        type;
+    ArgProcP        proc;
+    void           *closure;
     union {
-	char *		name;
-	EStringT *	message;
+	char       *name;
+	EStringT   *message;
     } u;
 } ArgListT;
 
@@ -220,7 +220,7 @@ extern void			write_arg_usage
  * This macro should be used to terminate an option list.
  */
 #define ARG_PARSE_END_LIST \
-{NULL, '\0',(ArgTypeT)0, NULL, NULL, \
- { NULL } }
+{NULL, '\0', (ArgTypeT)0, NULL, NULL, \
+ { NULL }}
 
 #endif /* !defined (H_ARG_PARSE) */


### PR DESCRIPTION
sid's arg-parse.h cast all callback function pointers into:

    void (*ArgProcP)(char *, ArgUsageT *, void *, ...)

The functions that sid used all took explicit arguments for the ... part of the function prototype.  For example, the callback function used to parse the `-l` argument is:

    static void
    main_handle_language(char *option, ArgUsageT *usage,
        void *gclosure, char *language_str)

This was cast into the ArgProcP function pointer type, and then called directly in arg-parse.c:

    chosen->proc(option, &closure, chosen->closure, tmp_argv[0]);

There's nothing that guarantees that the variable arguments passed to varargs-declared functions (eg: those with ellipses in their parameter list) will be passed the same way as declared arguments.  In fact, on macOS 13 running on arm64, they are not, resulting in undefined behavior.

Looking at the arg-parse.h behavior, there are only five different kinds of callbacks: awitch callback, where the extra argument is a bool, a callback with no arguments, and callbacks that take either one, two, or three char * arguments.  This suggests a simple solution:

- Instead of defining ArgProcP to take variadic arguments, define it to take no additional arguments
- During argument handling, use the value of ArgTypeT to cast the function pointer to a more specific type.

To this end, I've defined four addition function pointer types:

    typedef void(*ArgProcPSw)(char *, ArgUsageT *, void *, bool);
    typedef void(*ArgProcP1)(char *, ArgUsageT *, void *, char *);
    typedef void(*ArgProcP2)(char *, ArgUsageT *, void *, char *, char *);
    typedef void(*ArgProcP3)(char *, ArgUsageT *, void *, char *, char *, char *);

The argument parsing code in arg-parse.c now casts the callbacks to the appropriate ArgProcP* type before calling the function.