### PR TITLE
add glibc 2.39 (Ubuntu 24.04 "noble").

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,9 @@ on: [push, pull_request]
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest] # macos-latest
+        os: [ubuntu-24.04] # macos-latest
         target: [x32_64] # x86_32
         cc: [gcc, clang]
     runs-on: ${{ matrix.os }}

--- a/osdep/machines/glibc/common/include/features.h
+++ b/osdep/machines/glibc/common/include/features.h
@@ -4,8 +4,8 @@
 #if defined(_GLIBC2_12) || defined(_GLIBC2_14) || defined(_GLIBC2_15) \
 	|| defined(_GLIBC2_17) || defined(_GLIBC2_18) || defined(_GLIBC2_19) \
 	|| defined(_GLIBC2_23) || defined(_GLIBC2_27) || defined(_GLIBC2_28) \
-	|| defined(_GLIBC2_30) || defined(_GLIBC2_31) \
-	|| defined(_GLIBC2_32)
+	|| defined(_GLIBC2_30) || defined(_GLIBC2_31) || defined(_GLIBC2_32) \
+	|| defined(_GLIBC2_39)
 #pragma TenDRA begin
 #pragma TenDRA directive warning allow
 #endif
@@ -15,8 +15,8 @@
 #if defined(_GLIBC2_12) || defined(_GLIBC2_14) || defined(_GLIBC2_15) \
 	|| defined(_GLIBC2_17) || defined(_GLIBC2_18) || defined(_GLIBC2_19) \
 	|| defined(_GLIBC2_23) || defined(_GLIBC2_27) || defined(_GLIBC2_28) \
-	|| defined(_GLIBC2_30) || defined(_GLIBC2_31) \
-	|| defined(_GLIBC2_32)
+	|| defined(_GLIBC2_30) || defined(_GLIBC2_31) || defined(_GLIBC2_32) \
+	|| defined(_GLIBC2_39)
 #pragma TenDRA end
 #endif
 

--- a/osdep/machines/glibc/common/include/float.h
+++ b/osdep/machines/glibc/common/include/float.h
@@ -10,8 +10,8 @@
 	|| defined(_GLIBC2_12) || defined(_GLIBC2_14) || defined(_GLIBC2_15) \
 	|| defined(_GLIBC2_17) || defined(_GLIBC2_18) || defined(_GLIBC2_19) \
 	|| defined(_GLIBC2_23) || defined(_GLIBC2_27) || defined(_GLIBC2_28) \
-	|| defined(_GLIBC2_30) || defined(_GLIBC2_31) \
-	|| defined(_GLIBC2_32)
+	|| defined(_GLIBC2_30) || defined(_GLIBC2_31) || defined(_GLIBC2_32) \
+	|| defined(_GLIBC2_39)
 
 #include <proxy/include/float.h>
 

--- a/osdep/machines/glibc/common/include/math.h
+++ b/osdep/machines/glibc/common/include/math.h
@@ -13,7 +13,8 @@
 #endif
 
 #if defined(_GLIBC2_27) || defined(_GLIBC2_28) || defined(_GLIBC2_30) \
-	|| defined(_GLIBC2_31) || defined(_GLIBC2_32)
+	|| defined(_GLIBC2_31) || defined(_GLIBC2_32) || defined(_GLIBC2_39)
+
 #pragma TenDRA begin
 #pragma TenDRA directive warning allow
 #endif
@@ -21,7 +22,7 @@
 #include_next <math.h>
 
 #if defined(_GLIBC2_27) || defined(_GLIBC2_28) || defined(_GLIBC2_30) \
-	|| defined(_GLIBC2_31) || defined(_GLIBC2_32)
+	|| defined(_GLIBC2_31) || defined(_GLIBC2_32) || defined(_GLIBC2_39)
 #pragma TenDRA end
 #endif
 

--- a/osdep/machines/glibc/common/include/stdarg.h
+++ b/osdep/machines/glibc/common/include/stdarg.h
@@ -5,8 +5,8 @@
 	|| defined(_GLIBC2_12) || defined(_GLIBC2_14) || defined(_GLIBC2_15) \
 	|| defined(_GLIBC2_17) || defined(_GLIBC2_18) || defined(_GLIBC2_19) \
 	|| defined(_GLIBC2_23) || defined(_GLIBC2_27) || defined(_GLIBC2_28) \
-	|| defined(_GLIBC2_30) || defined(_GLIBC2_31) \
-	|| defined(_GLIBC2_32)
+	|| defined(_GLIBC2_30) || defined(_GLIBC2_31) || defined(_GLIBC2_32) \
+	|| defined(_GLIBC2_39)
 
 /*
  * The definition of va_list is compatible with the system header.

--- a/osdep/machines/glibc/common/include/stddef.h
+++ b/osdep/machines/glibc/common/include/stddef.h
@@ -10,8 +10,8 @@
 	|| defined(_GLIBC2_12) || defined(_GLIBC2_14) || defined(_GLIBC2_15) \
 	|| defined(_GLIBC2_17) || defined(_GLIBC2_18) || defined(_GLIBC2_19) \
 	|| defined(_GLIBC2_23) || defined(_GLIBC2_27) || defined(_GLIBC2_28) \
-	|| defined(_GLIBC2_30) || defined(_GLIBC2_31) \
-	|| defined(_GLIBC2_32)
+	|| defined(_GLIBC2_30) || defined(_GLIBC2_31) || defined(_GLIBC2_32) \
+	|| defined(_GLIBC2_39)
 
 #if defined(_ARCH_x86_32) || defined(_ARCH_x32_64)
 typedef unsigned int size_t;

--- a/osdep/machines/glibc/common/startup/c89.h
+++ b/osdep/machines/glibc/common/startup/c89.h
@@ -7,8 +7,8 @@
 #if defined(_GLIBC2_12) || defined(_GLIBC2_15) || defined(_GLIBC2_17) \
 	|| defined(_GLIBC2_19) \
 	|| defined(_GLIBC2_23) || defined(_GLIBC2_27) || defined(_GLIBC2_28) \
-	|| defined(_GLIBC2_30) || defined(_GLIBC2_31) \
-	|| defined(_GLIBC2_32)
+	|| defined(_GLIBC2_30) || defined(_GLIBC2_31) || defined(_GLIBC2_32) \
+	|| defined(_GLIBC2_39)
 #define __STRICT_ANSI__
 #endif
 

--- a/shared/mk/tendra.makedefs.mk
+++ b/shared/mk/tendra.makedefs.mk
@@ -149,6 +149,7 @@ MD_OSVER!=                                \
         Linux.3.1*)    echo LINUX31;;     \
         Linux.3.7*)    echo LINUX37;;     \
         Linux.5.4*)    echo LINUX54;;     \
+        Linux.6.8*)    echo LINUX68;;     \
         NetBSD.4*)     echo NETBSD4;;     \
         NetBSD.5.1*)   echo NETBSD5_1;;   \
         OpenBSD.3*)    echo OPENBSD3;;    \
@@ -196,6 +197,7 @@ MD_LIBCVER!=                              \
         GLIBC_2_30*)   echo GLIBC2_30;;   \
         GLIBC_2_31*)   echo GLIBC2_31;;   \
         GLIBC_2_32*)   echo GLIBC2_32;;   \
+        GLIBC_2_39*)   echo GLIBC2_39;;   \
         MUSL_1_1_5)    echo MUSL1_1_5;;   \
         *)             echo ${MD_OSVER};; \
     esac;


### PR DESCRIPTION
May be you want this. I've just blindly redone previous commit for glibc 2.28. GitHub CI can't run Ubuntu 18.04 anymore.

PS Clang finds incompatible conventions pointer to int in POWER trans. That's why second CI job fails.