### PR TITLE
Fix some documentation issues:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ test-doc:
 # XXX: need the per-project prefix that -DWEBSITE uses
 build-doc:
 	@echo "===> building documents"
-.for project in calculus trans lexi \
+.for project in calculus lexi \
 	osdep tdf tdfc2 sid tcc doc tld tnc tpl tspec
 	cd ${.CURDIR}/${project}/doc && ${MAKE} \
 	    -DDEVELOPER OBJ_DIR=${OBJ_DOC}/${project}

--- a/make_tdf/man/make_tdf.5/make_tdf.5.xml
+++ b/make_tdf/man/make_tdf.5/make_tdf.5.xml
@@ -102,8 +102,8 @@
 			<tbody>
 				<tr> <td><code>%SN</code></td> <td>sort</td> <td>Sort name</td> </tr>
 				<tr> <td><code>%ST</code></td> <td>sort</td> <td>Sort name in capitals</td> </tr>
-				<tr> <td><code>%SL</code></td> <td>sort</td> <td>Sort unit name</td> </tr>
-				<tr> <td><code>%SU</code></td> <td>sort</td> <td>Sort unit name</td> </tr>
+				<tr> <td><code>%SL</code></td> <td>sort</td> <td>Linkable entity identification</td> </tr>
+				<tr> <td><code>%SU</code></td> <td>sort</td> <td>Unit identificaiton</td> </tr>
 
 				<tr> <td><code>%SB</code></td> <td>sort</td> <td>Bits in encoding</td> </tr>
 				<tr> <td><code>%SE</code></td> <td>sort</td> <td>Extended encoding</td> </tr>
@@ -116,27 +116,27 @@
 
 		<programlisting language="bnf"><![CDATA[
 <sort_escape> :
-	N
-	T
-	L
-	U
-	B
-	E
-	M
+	N                       # Sort name
+	T                       # Sort name in capitals
+	L                       # Linkable entity identification
+	U                       # Unit identificaiton
+	B                       # Number of encoding bits
+	E                       # Extended encodin
+	M                       # Maximum encoding
 	C<construct_escape>
-	S<sort_escape>
+	S<sort_escape>          # Sub-sort of lists or options
 	X
 
 <construct_escape> :
-	N
-	E
-	S<sort_escape>
+	N                       # Name
+	E                       # Encoding number
+	S<sort_escape>          # Sort escape for corresponding sort
 	X
 
 <param_escape> :
-	N
-	S<sort_escape>
-	E
+	N                       # Parameter name
+	S<sort_escape>          # Sort escape for corresponding sort
+	E                       # Parameter index
 
 <digit> : one of
 	0 1 2 3 4 5 6 7 8 9
@@ -145,17 +145,17 @@
 	<digit><escape>
 	C<construct_escape>
 	P<param_escape>
-	VA
-	VB
-	ZV
-	ZX
+	VA                      # Version (major)
+	VB                      # Version (minor)
+	ZV                      # make_tdf
+	ZX                      # make_tdf version
 	b
 	t
 	u
 	%
 	@
 	_
-	<newline>
+	<newline>               # Escape new line
 
 ]]></programlisting>
 	</refsection>
@@ -218,7 +218,7 @@
 	link				# sort is linkage entity
 	unit				# sort is a unit sort
 	name.<construct_cond>		# refers to sortname
-	sub.<sort_cond>			# refers to sub-sort
+	sub.<sort_cond>			# refers to sub-sort of list or option
 	eq.<sort_name>			# sort has given name
 
 <construct_cond> :

--- a/tdf/doc/guide/models.xml
+++ b/tdf/doc/guide/models.xml
@@ -72,18 +72,18 @@ REPR[{short_variety}] = 16</programlisting>
             
 			<para>The representation of a compound ALIGNMENT is given by:</para>
             
-			<programlisting language="tdf">REPR[A xc8 B] = Max(REPR[A], REPR[B])
+			<programlisting language="tdf">REPR[A ∪ B] = Max(REPR[A], REPR[B])
 i.e. MAP[unite_alignment] = Max</programlisting>
             
 			<para>while the ALIGNMENT inclusion predicate is given by:</para>
 
-			<programlisting language="tdf">REPR[A ... B]= REPR[A] xb3 REPR[B]</programlisting>
+			<programlisting language="tdf">REPR[A ... B]= REPR[A] ⊃ REPR[B]</programlisting>
 
 			<para>All the constructions which make ALIGNMENTs are represented here
 				and they will always reduce to an integer known at translate-time.
-				Note that the mappings for xc8 and ... must preserve the basic
+				Note that the mappings for ∪ and ... must preserve the basic
 				algebraic properties derived from sets; for example the mapping of
-				xc8 must be idempotent, commutative and associative, which is true
+				∪ must be idempotent, commutative and associative, which is true
 				for Max.</para>
 		</section>
 
@@ -92,7 +92,7 @@ i.e. MAP[unite_alignment] = Max</programlisting>
 
 			<para>Most standard architectures use byte addressing; to address
 				bits requires more complication. Hence, a value with SHAPE
-				POINTER(A) where REPR[A)]xb9 1 is represented by a 32-bit byte
+				POINTER(A) where REPR[A] ≠ 1 is represented by a 32-bit byte
 				address.</para>
 
 			<para>We are not allowed to construct pointers where REPR[A] = 1,
@@ -100,7 +100,7 @@ i.e. MAP[unite_alignment] = Max</programlisting>
 				Thus a offsets to bitfield are represented differently to offsets
 				to other alignments:</para>
 
-			<para>A value with SHAPE OFFSET(A, B) where REPR(B) xb9 1 is
+			<para>A value with SHAPE OFFSET(A, B) where REPR(B) ≠ 1 is
 				represented by a 32-bit byte-offset.</para>
 
 			<para>A value with SHAPE OFFSET(A, B) where REPR(B) = 1 is
@@ -134,7 +134,7 @@ REPR[offset_zero(A)] = 0             for all A
 
 REPR[offset_pad(A, X:OFFSET(C, D)) =
     ((REPR[X] + REPR[A] - 1) / (REPR[A])) * REPR[A] / 8
-        if REPR[A] xb9 1 xd9 REPR[D] =1</programlisting>
+        if REPR[A] ≠ 1 Λ REPR[D] =1</programlisting>
 
 			<para>Otherwise:</para>
 
@@ -143,7 +143,7 @@ REPR[offset_pad(A, X:OFFSET(C, D)) =
     ((REPR[X] + REPR[A] - 1) / (REPR[A])) * REPR[A]
 
 REPR[offset_add(X:OFFSET(A, B), Y:OFFSET(C, D))] = REPR[X] * 8 + REPR[Y]
-        if REPR[B] xb9 1 xd9 REPR[D] = 1</programlisting>
+        if REPR[B] ≠ 1 Λ REPR[D] = 1</programlisting>
 
             <para>Otherwise:</para>
 
@@ -151,9 +151,9 @@ REPR[offset_add(X:OFFSET(A, B), Y:OFFSET(C, D))] = REPR[X] * 8 + REPR[Y]
 REPR[offset_add(X, Y)] = REPR[X] + REPR[Y]
 
 REPR[offset_max(X:OFFSET(A, B), Y:OFFSET(C, D))] = Max(REPR[X], 8 * REPR[Y]
-        if REPR[B] = 1 xd9 REPR[D] xb9 1
+        if REPR[B] = 1 Λ REPR[D] ≠ 1
 REPR[offset_max(X:OFFSET(A, B), Y:OFFSET(C, D))] = Max(8 * REPR[X], REPR[Y]
-        if REPR[D] = 1 xd9 REPR[B] xb9 1</programlisting>
+        if REPR[D] = 1 Λ REPR[B] ≠ 1</programlisting>
 
 			<para>Otherwise:</para>
 
@@ -166,7 +166,7 @@ REPR[offset_mult(X, E)] = REPR[X] * REPR[E]</programlisting>
 				integers and their inclusion constraints into numerical
 				comparisons.  As a result, it will correctly allow many OFFSETs
 				which are disallowed in general; for example, OFFSET({pointer},
-				{char_variety}) is allowed since REPR[{pointer}] xb3
+				{char_variety}) is allowed since REPR[{pointer}] ⊃
 				REPR[{char_variety}]. Rather fewer of these extra relationships
 				are allowed in the next model considered.</para>
 		</section>
@@ -213,11 +213,11 @@ REPR[alignment({local_label_value})] = (s:32, b:TRUE)</programlisting>
 
 			<para>The representation of a compound ALIGNMENT is given by:</para>
 
-			<programlisting language="tdf">REPR[A xc8 B] = (s:Max(REPR[A].s, REPR[B].s), b:REPR[A].b xda REPR[B].b)</programlisting>
+			<programlisting language="tdf">REPR[A ∪ B] = (s:Max(REPR[A].s, REPR[B].s), b:REPR[A].b V REPR[B].b)</programlisting>
 		  
 			<para>and their inclusion relationship is given by:</para>
 
-			<programlisting language="tdf">REPR[A ... B] = (REPR[A].s xb3 REPR[B].s) xd9 (REPR[A].b xda REPR[B].b)</programlisting>
+			<programlisting language="tdf">REPR[A ... B] = (REPR[A].s ⊃ REPR[B].s) Λ (REPR[A].b V REPR[B].b)</programlisting>
 		</section>
 
 		<section>
@@ -273,41 +273,41 @@ REPR[shape_offset(top)] = 0</programlisting>
 REPR[offset_zero(A)] = (sd: 0, ad: 0) if REPR[A].b
 
 REPR[offset_add(X:OFFSET(A, B), Y:OFFSET(C, D))] = REPR[X] + REPR[Y]
-        if REPR[A].b xd9 REPR[C].b
+        if REPR[A].b Λ REPR[C].b
 REPR[offset_add(X:OFFSET(A, B), Y:OFFSET(C, D))] =
     (sd:REPR[X].sd + REPR[Y].sd, ad: REPR[X].ad + REPR[Y].ad)
-        if REPR[A].b xd9 REPR[C].b
+        if REPR[A].b Λ REPR[C].b
 REPR[offset_add(X:OFFSET(A, B), Y:OFFSET(C, D))] =
     (sd:REPR[X].sd + REPR[Y], ad:REPR[X].ad)
-        if REPR[A].b xd9 REPR[C].b
+        if REPR[A].b Λ REPR[C].b
 
 REPR[offset_pad(A, Y:OFFSET(C, D))] = (REPR[Y] + REPR[A].s - 1) / REPR[A].s
-        if REPR[A].b xd9 REPR[C].b
+        if REPR[A].b Λ REPR[C].b
 REPR[offset_pad(A, Y:OFFSET(C, D))] =
     (sd:(REPR[Y] + REPR[A].s - 1) / REPR[A].s, ad:REPR[Y].ad)
         if REPR[C].b
 REPR[offset_pad(A, Y: OFFSET(C, D))] =
     (sd:(REPR[Y] + REPR[A].s - 1) / REPR[A].s, ad:0)
-        if REPR[A].b xd9 REPR[C].b
+        if REPR[A].b Λ REPR[C].b
 REPR[offset_max(X:OFFSET(A, B), Y:OFFSET(C, D))] = Max(REPR[X], REPR[Y])
-        if REPR[A].b xd9 REPR[C].b
+        if REPR[A].b Λ REPR[C].b
 REPR[offset_max(X:OFFSET(A, B), Y:OFFSET(C, D))] =
     (sd:Max(REPR[X].sd, REPR[Y].sd), ad:Max(REPR[X].a, REPR[Y].ad))
-        if REPR[A].b xd9 REPR[C].b
+        if REPR[A].b Λ REPR[C].b
 REPR[offset_max(X:OFFSET(A, B), Y:OFFSET(C, D))] =
     (sd:Max(REPR[X].sd, REPR[Y]), ad:REPR[X].ad)
-        if REPR[A].b xd9 REPR[C].b
+        if REPR[A].b Λ REPR[C].b
 REPR[offset_max(X:OFFSET(A, B), Y:OFFSET(C, D))] =
     (sd:Max(REPR[Y].sd, REPR[X]), ad: REPR[Y].ad)
-        if REPR[C].b xd9 REPR[A].b
+        if REPR[C].b Λ REPR[A].b
 
 REPR[offset_subtract(X:OFFSET(A, B), Y:OFFSET(C, D))] = REPR[X] - REPR[Y]
-        if REPR[A].b xd9 REPR[C].b
+        if REPR[A].b Λ REPR[C].b
 REPR[offset_subtract(X:OFFSET(A,B), Y:OFFSET(C, D))] =
     (sd:REPR[X].sd - REPR[Y].sd, ad:REPR[X].ad - REPR[Y].ad)
-        if REPR[A].b xd9 REPR[C].b
+        if REPR[A].b Λ REPR[C].b
 REPR[offset_add(X:OFFSET(A, B), Y:OFFSET(C, D))] = REPR[X].sd - REPR[Y]
-        if REPR[A].b xd9 REPR[C].b
+        if REPR[A].b Λ REPR[C].b
 .... and so on.</programlisting>
             
 		<para>Unlike the previous one, this model of ALIGNMENTs would reject

--- a/tdf/doc/guide/offsetexpansion.xml
+++ b/tdf/doc/guide/offsetexpansion.xml
@@ -69,7 +69,7 @@
 		<para>From the definition, we find that:</para>
 
 		<programlisting language="tdf">S_c = shape_offset(SH_mystruct)
-			i.e. an OFFSET(alignment(sh_int) xc8  alignment(sh_char) xc8  alignment(sh_double), {})</programlisting>
+			i.e. an OFFSET(alignment(sh_int) ∪  alignment(sh_char) ∪  alignment(sh_double), {})</programlisting>
 
 		<para>This would not be the OFFSET required to describe
 			<code>sizeof(mystruct)</code> in C, since this is defined to be the
@@ -87,7 +87,7 @@
 			address of a structure or array element. Looking again at its
 			signature in a slightly different form:</para>
 
-		<programlisting language="tdf">arg1: EXP POINTER(y xc8 A)
+		<programlisting language="tdf">arg1: EXP POINTER(y ∪ A)
 arg2: EXP OFFSET(y, z)
  -&gt; EXP POINTER(z)
  ... for any ALIGNMENT A</programlisting>
@@ -174,7 +174,7 @@ issigned: BOOL
 n:        NAT
 issigned: BOOL
 sh:       SHAPE
- -&gt; EXP OFFSET(alignment(sh) xc8  A, bfvar_bits(issigned, n))</programlisting>
+ -&gt; EXP OFFSET(alignment(sh) ∪  A, bfvar_bits(issigned, n))</programlisting>
           
 		<para>Here the result is the shape_offset of <code>sh</code> padded with
 			the `minimum' alignment A so that it can accomodate the bitfield.

--- a/tdf/doc/guide/shapesalignmentsoffsets.xml
+++ b/tdf/doc/guide/shapesalignmentsoffsets.xml
@@ -397,7 +397,7 @@ maximum_exponent:: NAT
 
 			<programlisting language="tdf">a:    ALIGNMENT
 arg1: EXP OFFSET(z, t)
- -&gt; EXP OFFSET(z xc8 a, a)</programlisting>
+ -&gt; EXP OFFSET(z ∪ a, a)</programlisting>
 
 			<para>This gives the next OFFSET greater or equal to <code>arg1</code>
 				at which an object of ALIGNMENT <code>a</code> can be
@@ -507,9 +507,9 @@ arg2: EXP INTEGER(v)
 				alignment qualifiers, as given by offset_test and offset_max
 				having properties like:</para>
 
-			<programlisting language="tdf">shape_offset(S) xb3  offset_zero(alignment(S))
-A xb3  B        iff offset_max(A,B) = A
-offset_add(A, B) xb3  A         where B xb3  offset_zero(some compatible alignment)</programlisting>
+			<programlisting language="tdf">shape_offset(S) ≥ offset_zero(alignment(S))
+A ≥ B        iff offset_max(A,B) = A
+offset_add(A, B) ≥ A         where B ≥ offset_zero(some compatible alignment)</programlisting>
 
 			<para>In most machines, OFFSETs would be represented as single integer
 				values with the OFFSET ordering corresponding to simple integer

--- a/tdf/doc/guide/transformations.xml
+++ b/tdf/doc/guide/transformations.xml
@@ -81,7 +81,8 @@
 			generic transformations which can often help to answer knotty
 			questions.  Here, E[X \ Y] denotes an EXP E with all internal
 			occurrences of X replaced by Y.</para>
-
+		<itemizedlist>
+		<listitem>
 		<para>If F is any non order-specifying <footnote>
 				<para>The order-specifying constructors are conditional,
 					identify, repeat, labelled, sequence and
@@ -89,8 +90,10 @@
 			</footnote>
 			EXP constructor and E is one of the EXP operands of F, then:</para>
 
-		<programlisting language="tdf">F(..., E, ...) xde identify(empty, newtag, E, F(..., obtain_tag(newtag), ...))</programlisting>
+		<programlisting language="tdf">F(..., E, ...) → identify(empty, newtag, E, F(..., obtain_tag(newtag), ...))</programlisting>
+		</listitem>
 
+		<listitem>
 		<para>If E is a non side-effecting <footnote>
 				<para>A sufficient condition for not side-effecting in this sense
 					is that there are no apply_procs or local_allocs in E; that any
@@ -99,90 +102,133 @@
 					E.</para>
 			</footnote>
 			EXP and none of the variables used in E are assigned to in B:
-			identify(v, tag, E, B) xde B[obtain_tag(tag) \ E]</para>
+			identify(v, tag, E, B) → B[obtain_tag(tag) \ E]</para>
+		</listitem>
 
+		<listitem>
 		<para>If all uses of tg in B are of the form contents(shape(E),
 			obtain_tag(tg)):</para>
 
 		<programlisting language="tdf">
-variable(v, tg, E, B) xde identify(v, nt, E, B[contents(shape(E), obtain_tag(tg)) \ obtain_tag(nt)])
+variable(v, tg, E, B) → identify(v, nt, E, B[contents(shape(E), obtain_tag(tg)) \ obtain_tag(nt)])</programlisting>
+		</listitem>
+
+		<listitem>
+		<programlisting language="tdf">
 sequence((S<subscript>1</subscript>, ..., S<subscript>n</subscript>),
-         sequence((P<subscript>1</subscript>, ..., P<subscript>m</subscript>), R) xdb
+         sequence((P<subscript>1</subscript>, ..., P<subscript>m</subscript>), R) ↔
          sequence((S<subscript>1</subscript>, ..., S<subscript>n</subscript>, P<subscript>1</subscript>, ..., P<subscript>m</subscript>), R)</programlisting>
-          
+ 		</listitem>
+
+		<listitem>
 		<para>If S<subscript>i</subscript> =
 			sequence((P<subscript>1</subscript>, ...,
 			P<subscript>m</subscript>), R):</para>
 
-		<programlisting language="tdf">sequence((S<subscript>1</subscript>, ..., S<subscript>n</subscript>), T) xdb
+		<programlisting language="tdf">sequence((S<subscript>1</subscript>, ..., S<subscript>n</subscript>), T) ↔
          sequence((S<subscript>1</subscript>, ...,
                   S<subscript>i-1</subscript>, P<subscript>1</subscript>, ..., P<subscript>m</subscript>, R,
-                  S<subscript>i+1</subscript>, ..., S<subscript>n</subscript>), T) E xdb sequence((), E)</programlisting>
-          
+                  S<subscript>i+1</subscript>, ..., S<subscript>n</subscript>), T)</programlisting>
+ 		</listitem>
+
+		<listitem>
+		<programlisting language="tdf">E ↔ sequence((), E)</programlisting>
+ 		</listitem>
+
+		<listitem>
 		<para>If D is either identify or variable:</para>
 
-		<programlisting language="tdf">D(v, tag, sequence((S<subscript>1</subscript>, ..., S<subscript>n</subscript>), R), B) xde
+		<programlisting language="tdf">D(v, tag, sequence((S<subscript>1</subscript>, ..., S<subscript>n</subscript>), R), B) →
                    sequence((S<subscript>1</subscript>, ..., S<subscript>n</subscript>), D(v, tag, R, B))</programlisting>
-          
+ 		</listitem>
+
+		<listitem>
 		<para>If S<subscript>i</subscript> is an EXP BOTTOM, then:</para>
 
-		<programlisting language="tdf">sequence((S<subscript>1</subscript>, S<subscript>2</subscript>, ... S<subscript>n</subscript>), R) xde
+		<programlisting language="tdf">sequence((S<subscript>1</subscript>, S<subscript>2</subscript>, ... S<subscript>n</subscript>), R) →
 sequence((S<subscript>1</subscript>, ...  S<subscript>i - 1</subscript>), S<subscript>i</subscript>)</programlisting>
           
-          
+ 		</listitem>
+
+		<listitem>
 		<para>If E is an EXP BOTTOM, and if D is either identify or variable:</para>
 
-		<programlisting language="tdf">D(v, tag, E, B) xde E</programlisting>
+		<programlisting language="tdf">D(v, tag, E, B) → E</programlisting>
+ 		</listitem>
 
+		<listitem>
 		<para>If S<subscript>i</subscript> is make_top(), then:</para>
 
 		<programlisting language="tdf">sequence((S<subscript>1</subscript>,
-S<subscript>2</subscript>, ...  S<subscript>n</subscript>), R) xdb
+S<subscript>2</subscript>, ...  S<subscript>n</subscript>), R) ↔
 sequence((S<subscript>1</subscript>, ...  S<subscript>i - 1</subscript>,
 S<subscript>i + 1</subscript>, ...S<subscript>n</subscript>), R)</programlisting>
-          
+ 		</listitem>
+
+		<listitem>
 		<para>If S<subscript>n</subscript> is an EXP TOP:</para>
 
 		<programlisting language="tdf">sequence((S<subscript>1</subscript>, ...
-          S<subscript>n</subscript>), make_top()) xdb sequence((S<subscript>1</subscript>, ...,
+          S<subscript>n</subscript>), make_top()) ↔ sequence((S<subscript>1</subscript>, ...,
           S<subscript>n - 1</subscript>), S<subscript>n</subscript>)</programlisting>
-          
+ 		</listitem>
+
+		<listitem>
 		<para>If E is an EXP TOP and E is not side-effecting then:</para>
 
-		<programlisting language="tdf">E xde make_top()</programlisting>
+		<programlisting language="tdf">E → make_top()</programlisting>
+ 		</listitem>
 
+		<listitem>
 		<para>If C is some non order-specifying and non side-effecting
 			constructor, and S<subscript>i</subscript> is C(P<subscript>1</subscript>,...,
 			P<subscript>m</subscript>) where P<subscript>1..m</subscript> are the EXP operands of C:</para>
 
-		<programlisting language="tdf">sequence((S<subscript>1</subscript>, ..., S<subscript>n</subscript>), R) xde
+		<programlisting language="tdf">sequence((S<subscript>1</subscript>, ..., S<subscript>n</subscript>), R) →
 sequence((S<subscript>1</subscript>, ..., S<subscript>i - 1</subscript>, P<subscript>1</subscript>,
           ..., P<subscript>m</subscript>, S<subscript>i + 1</subscript>, ..., S<subscript>n</subscript>), R)</programlisting>
-          
+ 		</listitem>
+
+		<listitem>
 		<para>If none of the S<subscript>i</subscript> use the label L:</para>
 
 		<programlisting language="tdf">conditional(L,
-            sequence((S<subscript>1</subscript>, ..., S<subscript>n</subscript>), R), A) xde
+            sequence((S<subscript>1</subscript>, ..., S<subscript>n</subscript>), R), A) →
             sequence((S<subscript>1</subscript>, ..., S<subscript>n</subscript>), conditional(L, R, A))</programlisting>
-          
+ 		</listitem>
+
+		<listitem>
 		<para>If there are no uses of L in X: <footnote>
 				<para>There are analogous rules for labelled and repeat with
 					unused LABELs.</para>
 			</footnote></para>
 
-		<programlisting language="tdf">conditional(L, X, Y) xde X conditional(L, E, goto(Z)) xde E[L \ Z]</programlisting>
+		<programlisting language="tdf">conditional(L, X, Y) → X</programlisting>
+ 		</listitem>
 
+		<listitem>
+		<programlisting language="tdf">conditional(L, E, goto(Z)) → E[L \ Z]</programlisting>
+ 		</listitem>
+
+		<listitem>
 		<para>If EXP X contains no use of the LABEL L:</para>
 
-		<programlisting language="tdf">conditional(L, conditional(M, X, Y), Z) xde conditional(M, X, conditional(L, Y, Z))
-repeat(L, I, E) xde sequence((I), repeat(L, make_top(), E))
-repeat(L, make_top(), E) xde conditional(Z, E[L \ Z], repeat(L, make_top(), E))</programlisting>
-          
+		<programlisting language="tdf">conditional(L, conditional(M, X, Y), Z) → conditional(M, X, conditional(L, Y, Z))</programlisting>
+ 		</listitem>
+
+		<listitem>
+		<programlisting language="tdf">repeat(L, I, E) → sequence((I), repeat(L, make_top(), E))
+repeat(L, make_top(), E) → conditional(Z, E[L \ Z], repeat(L, make_top(), E))</programlisting>
+ 		</listitem>
+
+		<listitem>
 		<para>If there are no uses of L in E:</para>
 
-		<programlisting language="tdf">repeat(L, make_top(), sequence((S, E), make_top())) xde
+		<programlisting language="tdf">repeat(L, make_top(), sequence((S, E), make_top())) →
 conditional(Z, S[L \ Z], repeat(L, make_top(), sequence((E, S), make_top())))</programlisting>
+ 		</listitem>
 
+		<listitem>
 		<para>If f is a procedure defined <footnote>
 					<para>This has to be modified if B contains any uses of
 						local_free_all or last_local.</para>
@@ -199,7 +245,7 @@ conditional(Z, S[L \ Z], repeat(L, make_top(), sequence((E, S), make_top())))</p
 		<para>and B is an EXP with all of its internal return constructors indicated
 			parametrically then:</para>
 
-		<programlisting language="tdf">if Ai has SHAPE si apply_proc(rshape, f, (A1, ..., An), V) xde
+		<programlisting language="tdf">if Ai has SHAPE si apply_proc(rshape, f, (A1, ..., An), V) →
 variable(empty, newtag, make_value((rshape=BOTTOM) ?  TOP : rshape),
          labelled((L), variable(v1, tg1, A1, ...,
                   variable(vn, tgn, An,
@@ -207,15 +253,32 @@ variable(empty, newtag, make_value((rshape=BOTTOM) ?  TOP : rshape),
                   B(sequence(assign(obtain_tag(newtag), R1), goto(L)),
                     ...,
                     sequence(assign(obtain_tag(newtag), Rm), goto(L))))),
-                  contents(rshape, obtain_tag(newtag))))
-assign(E, make_top()) xde sequence((E), make_top())
-contents(TOP, E) xde sequence((E), make_top())
-make_value(TOP) xde make_top()
-component(s, contents(COMPOUND(S), E), D) xde contents(s, add_to_ptr(E, D))
-make_compound(S, ((E1, D1), ..., (En, Dn))) xde variable(empty, nt, make_value(COMPOUND(S)),
+                  contents(rshape, obtain_tag(newtag))))</programlisting>
+ 		</listitem>
+
+		<listitem>
+		<programlisting language="tdf">assign(E, make_top()) → sequence((E), make_top())</programlisting>
+ 		</listitem>
+
+		<listitem>
+		<programlisting language="tdf">contents(TOP, E) → sequence((E), make_top())</programlisting>
+ 		</listitem>
+
+		<listitem>
+		<programlisting language="tdf">make_value(TOP) → make_top()</programlisting>
+ 		</listitem>
+
+		<listitem>
+		<programlisting language="tdf">component(s, contents(COMPOUND(S), E), D) → contents(s, add_to_ptr(E, D))</programlisting>
+ 		</listitem>
+
+		<listitem>
+		<programlisting language="tdf">make_compound(S, ((E1, D1), ..., (En, Dn))) → variable(empty, nt, make_value(COMPOUND(S)),
     sequence((assign(add_to_ptr(obtain_tag(nt), D1), E1), ...,
               assign(add_to_ptr(obtain_tag(nt), Dn), En)),
              contents(S, obtain_tag(nt))))</programlisting>
+ 		</listitem>
+		</itemizedlist>
 	</section>
 
 	<section id="examples-of-transformations">

--- a/tdf/doc/specification/constructs.xml
+++ b/tdf/doc/specification/constructs.xml
@@ -4824,12 +4824,17 @@ max_exponent:  NAT
 				will choose one to minimise space requirements or maximise the speed of
 				operations.</para>
 
-			<para>All numbers of the form xb1	M*<replaceable>base N+1-q</replaceable> are
-				required to be represented exactly where M and N are integers such
-			that <replaceable>base</replaceable><replaceable>q-1</replaceable>	M &lt;
-			<replaceable>base</replaceable><replaceable>q</replaceable>
-				-<replaceable>min_exponent</replaceable>	N <replaceable>max_exponent</replaceable>
+			<para>All numbers of the form M*<replaceable>base</replaceable><superscript>N+1-q</superscript> are
+				required to be represented exactly where M and N are integers such that
 			</para>
+			<itemizedlist>
+				<listitem>
+					<para><replaceable>base<superscript>q-1</superscript></replaceable> ≤ M &lt; <replaceable>base<superscript>q</superscript></replaceable></para>
+				</listitem>
+				<listitem>
+					<para>-<replaceable>min_exponent</replaceable> ≤ N ≤ <replaceable>max_exponent</replaceable></para>
+				</listitem>
+			</itemizedlist>
 
 			<para>Zero will also be represented exactly in any
 				<code>FLOATING_VARIETY</code>.</para>


### PR DESCRIPTION
Replace weird operators with Unicode in the docs:

* xb1 - ≥
* xc8 - ∪
* xb3 - ⊃
* xb9 - ≠
* xd9 - Λ
* xda - V
* xdb - ↔
* xde - →

Restore ordered items in transformations section.

Update `make_tdf.5.xml` man page.